### PR TITLE
tools: cherry-pick reverts cherry-picks from ubuntu/daily/*

### DIFF
--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -7,7 +7,14 @@ covers releases xenial+.
 Ubuntu packaging is stored as branches in the upstream cloud-init
 repo.  For example, see the ``ubuntu/devel``, ``ubuntu/xenial`` ... branches in the [upstream git repo](https://git.launchpad.net/cloud-init/).  Note that changes to the development release are always done in ubuntu/devel, not ubuntu/<release-name>.
 
-To suppport daily recipe builds, there are related ``ubuntu/daily/devel``, ``ubuntu/daily/xenial``, ... branches which are used to support our daily recipe package builds. The ubuntu/daily/$release branches are snapshots of ubuntu/$release branches with any cherry picks reverted so that our build recipe can merge tip of master into ubuntu/$release without merge conflicts.
+We build cloud-init master with each release branch to provide a daily
+cloud-init for each of the releases we support. Certain features and behavior
+changes are disabled in release branches. These release branch changes may
+prevent master from merging with the release branch and break the daily recipe
+builds.
+To resolve this conflict we provide fixes (reverting cherry picks or other
+feature redactions) to the release branches in a separate branch named
+ubuntu/daily/$release branch. For example ubuntu/daily/devel, ubuntu/daily/xenial.
 
 Note, that there is also the git-ubuntu cloud-init repo (aka "ubuntu server dev importer") at [lp:~usd-import-team/ubuntu/+source/cloud-init](https://code.launchpad.net/~usd-import-team/ubuntu/+source/cloud-init/+git/cloud-init).
 
@@ -121,7 +128,9 @@ This is generally not the preferred mechanism for any release supported by trunk
 
 #### Cherry-pick Process
 ```
-  $ git fetch upstream; git checkout upstream/ubuntu/xenial -b ubuntu/xenial
+  $ git fetch upstream
+  $ git checkout -b ubuntu/xenial upstream/ubuntu/xenial || git checkout ubuntu/xenial
+  $ git reset --hard upstream/ubuntu/xenial
   $ cherry-pick <new_cherry_pick_commitish>
   $ cherry-pick <commit_hash_2>
   # Put up two PRs for review ubuntu/$release and ubuntu/daily/$release
@@ -218,9 +227,10 @@ We have daily packaging recipes which upload to the [daily ppa](https://code.lau
 
 ### When the daily recipe build fails ###
 
-The daily recipe for each release checks out master and then merges the ubuntu/$release and finally merged ubuntu/daily/$release
-and builds the package from there.  From time to time, the patches in the
-ubuntu/$release branch need to be refreshed/updated as upstream/master changes.
+The daily recipe for each release checkouts master, merges both
+ubuntu/$release and ubuntu/daily/$release and builds the package from there.
+From time to time, the patches in the ubuntu/$release branch need to be
+refreshed as upstream/master changes.
 
 
 The example build recipe for each release follows this general format:

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -150,7 +150,7 @@ From here you follow along with the snapshot upload process from
 
 After uploading a cherry-pick release, the daily builds will break
 unless we also revert the cherry-picks from the ubuntu/daily/$release branch.
-This is because the recipe will merge ubuntu/daily into master, and will get
+This is because the recipe will merge ubuntu/$release into master, and will get
 conflicts re-applying the cherry-picked patch because it already exists.
 The `cherry-pick` tool takes care of reverting any cherry picks from
 ubuntu/daily/$release branches. 
@@ -162,12 +162,12 @@ different prefix, and avoid reverting that cpick from ubunut/daily/$release.
 
 
 
-After both ubuntu/$release and ubuntu/daily/$release PRs are merged, go to the recipe pages (see below)
-and click build-now.
+After both ubuntu/$release and ubuntu/daily/$release PRs are merged, go to the
+recipe pages (see below) and click build-now.
 
 ### Adding a quilt patch to debian/patches ###
 This is generally needed when we are disabling backported feature from tip
-in order to retain existing behavior on a older series.
+in order to retain existing behavior on an older series.
 
 The procedure is as follows:
 

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -11,10 +11,10 @@ We build cloud-init master with each release branch to provide a daily
 cloud-init for each of the releases we support. Certain features and behavior
 changes are disabled in release branches. These release branch changes may
 prevent master from merging with the release branch and break the daily recipe
-builds.
-To resolve this conflict we provide fixes (reverting cherry picks or other
-feature redactions) to the release branches in a separate branch named
-ubuntu/daily/$release branch. For example ubuntu/daily/devel, ubuntu/daily/xenial.
+builds. To resolve this conflict we provide fixes (reverting cherry picks or
+other feature redactions) to the release branches in a separate branch named
+ubuntu/daily/$release branch. For example ubuntu/daily/devel,
+ubuntu/daily/xenial.
 
 Note, that there is also the git-ubuntu cloud-init repo (aka "ubuntu server dev importer") at [lp:~usd-import-team/ubuntu/+source/cloud-init](https://code.launchpad.net/~usd-import-team/ubuntu/+source/cloud-init/+git/cloud-init).
 

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -7,14 +7,8 @@ covers releases xenial+.
 Ubuntu packaging is stored as branches in the upstream cloud-init
 repo.  For example, see the ``ubuntu/devel``, ``ubuntu/xenial`` ... branches in the [upstream git repo](https://git.launchpad.net/cloud-init/).  Note that changes to the development release are always done in ubuntu/devel, not ubuntu/<release-name>.
 
-We build cloud-init master with each release branch to provide a daily
-cloud-init for each of the releases we support. Certain features and behavior
-changes are disabled in release branches. These release branch changes may
-prevent master from merging with the release branch and break the daily recipe
-builds. To resolve this conflict we provide fixes (reverting cherry picks or
-other feature redactions) to the release branches in a separate branch named
-ubuntu/daily/$release branch. For example ubuntu/daily/devel,
-ubuntu/daily/xenial.
+Additionally there are ``ubuntu/daily/$release`` branches which are used for
+[daily packaging recipes](#daily-packaging-recipes-and-ppa).
 
 Note, that there is also the git-ubuntu cloud-init repo (aka "ubuntu server dev importer") at [lp:~usd-import-team/ubuntu/+source/cloud-init](https://code.launchpad.net/~usd-import-team/ubuntu/+source/cloud-init/+git/cloud-init).
 
@@ -43,7 +37,7 @@ new-upstream-release does:
 
   * merge master into the packaging branch so that history is maintained.
   * strip out core contributors from attribution in the debian changelog entries.
-  * makes changes to debian/patches/series and drops any cherry-picks in that directory.
+  * make changes to debian/patches/series and drop any cherry-picks in that directory.
   * refreshes any remaining patches in debian/patches/
 
   * opens $EDITOR with an option to edit debian/changelog.  In SRU, I will generally strip out commits that are not related to ubuntu, and also strip out or join any fix/revert/fixup commits into one.  Note this is a *ubuntu* changelog, so it makes sense that it only have Ubuntu specific things listed.
@@ -218,7 +212,12 @@ If there were a number of releases that were missed you could do
 
 
 ## Daily packaging recipes and ppa ##
-We have daily packaging recipes which upload to the [daily ppa](https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily).  These build Ubuntu packaging on top of trunk.  This differs from trunk built for the given Ubuntu release because the Ubuntu release may have patches applied.
+We have daily packaging recipes which upload to the [daily ppa](https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily).  These build Ubuntu packaging from tip of master with ubuntu/$release and ubuntu/daily/$release branches applied so the recipe can encorporate any $release-specific behavioral patches to
+tip of master before the build.
+
+The ubuntu/daily/$release branches are only present to revert any cherry-pick
+debian/patches/*cpick* files which are already included in tip of master.
+
 
   * [xenial](https://code.launchpad.net/~cloud-init-dev/+recipe/cloud-init-daily-xenial)
   * [bionic](https://code.launchpad.net/~cloud-init-dev/+recipe/cloud-init-daily-bionic)
@@ -232,15 +231,13 @@ ubuntu/$release and ubuntu/daily/$release and builds the package from there.
 From time to time, the patches in the ubuntu/$release branch need to be
 refreshed as upstream/master changes.
 
-
 The example build recipe for each release follows this general format:
-
-Checkout cloud-init tip, merge ubuntu/$release which may have cpicks, merge ubuntu/daily/$release which revert debian/patches/cpick-\* because those cpicks are already included in tip.
 
 Ubuntu devel daily recipe:
 
 ```
 # git-build-recipe format 0.4 deb-version {latest-tag}-{revno}-g{git-commit}-0ubuntu1+{revno:ubuntu-pkg}~trunk
+# Recipe doc: https://github.com/canonical/uss-tableflip/blob/master/doc/ubuntu_release_process.md
 lp:cloud-init master
 merge ubuntu-pkg lp:cloud-init ubuntu/devel
 merge ubuntu-pkg-daily lp:cloud-init ubuntu/daily/devel

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -44,7 +44,7 @@ new-upstream-release does:
   * merge master into the packaging branch so that history is maintained.
   * strip out core contributors from attribution in the debian changelog entries.
   * makes changes to debian/patches/series and drops any cherry-picks in that directory.
-  * refreshes any patches in debian/patches/
+  * refreshes any remaining patches in debian/patches/
 
   * opens $EDITOR with an option to edit debian/changelog.  In SRU, I will generally strip out commits that are not related to ubuntu, and also strip out or join any fix/revert/fixup commits into one.  Note this is a *ubuntu* changelog, so it makes sense that it only have Ubuntu specific things listed.
 
@@ -71,8 +71,8 @@ The process goes like this:
 
     ## Your '$EDITOR' will be opened with the chance to change the
     ## changelog entry.
-    ##   FIXME: If this is a a SRU, then you should ideally edit the packaging
-    ##   portion of the version string to contain ~XX.YY.N
+    ##   FIXME: If this is the first SRU to a stable release, then you should
+    ##   edit the packaging portion of the version string to contain ~XX.YY.N
     ##   For example: 0.7.9-233-ge586fe35-0ubuntu1~16.04.1
     ##   It will **not** automatically add the '~16.04.1' portion.
     ##
@@ -147,9 +147,9 @@ The `cherry-pick` tool will:
   * call quilt push -a
   * prompt for commiting the debian/changelog
   * checkout upstream/ubuntu/daily/$release branch
-  * git cherry-pick the commit which added the debian/patches/cpick-\* into the
-    ubuntu/daily/$release branch
-  * git revert the cpick commit from ubuntu/daily/$release
+  * git reset --hard ubuntu/$release
+  * git revert commits which created or changed debian/patches/*cpick* files
+  * git checkout ubuntu/$release
 
 From here you follow along with the snapshot upload process from
 [`dch --release` and beyond](#upstream-snapshot-process).

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -90,6 +90,10 @@ git_log_to_dch() {
     fi
 }
 
+gitcmd() {
+    git "$@" || fail "Failed running git $@"
+}
+
 run_quilt() {
     local diffargs="-p ab --no-timestamps --no-index"
     QUILT_PATCHES="debian/patches" \
@@ -105,40 +109,36 @@ NEW_VERSION=""
 
 drop_cherry_pick_from_daily_branch() {
     local local_cpick_commit="$1" daily_remote="$2"
-    cur_br=$(git rev-parse --abbrev-ref HEAD) ||
-        { error "failed to get current branch name"; return 1; }
+    cur_br=$(gitcmd rev-parse --abbrev-ref HEAD)
     daily_br=${cur_br/ubuntu/ubuntu\/daily}
-    git fetch ${daily_remote}
+    gitcmd fetch ${daily_remote}
     echo "Backing out cherry-pick from ${daily_br} branch"
-    if [ $(git show-ref refs/heads/${daily_br}) ]; then
+    if [ ! -z "$(gitcmd show-ref refs/heads/${daily_br})" ]; then
         # Branch already exists so refresh it to remote/ubuntu/daily/<series>
-        git checkout ${daily_br}
-        git reset --hard ${daily_remote}/${daily_br}
+        gitcmd checkout ${daily_br}
+        gitcmd reset --hard ${daily_remote}/${daily_br}
     else
         # Create local checkout for daily branch
-        git checkout ${daily_remote}/${daily_br} -b ${daily_br}
+        gitcmd checkout ${daily_remote}/${daily_br} -b ${daily_br}
     fi
-    git cherry-pick ${local_cpick_commit}
-    git revert ${local_cpick_commit}
+    gitcmd cherry-pick ${local_cpick_commit}
+    gitcmd revert ${local_cpick_commit}
     # switch back to current development branch
-    git checkout ${cur_br}
+    gitcmd checkout ${cur_br}
 }
 
 apply_one_cherry_pick() {
     local r="" commit_in="$1" daily_remote="$2" chash="" shash="" sname=""
     local fname="" cur_br=""
-    cur_br=$(git rev-parse --abbrev-ref HEAD) ||
-        { error "failed to get current branch"; return 1; }
-    chash=$(git show --quiet "--pretty=format:%H" "${commit_in}") ||
-        { error "failed git show $commit_in"; return 1; }
+    cur_br=$(gitcmd rev-parse --abbrev-ref HEAD)
+    chash=$(gitcmd show --quiet "--pretty=format:%H" "${commit_in}")
 
     if git merge-base --is-ancestor "$chash" HEAD; then
         error "current branch '$cur_br' already contains $commit_in ($chash)"
         return 1
     fi
 
-    out=$(git show --abbrev=8 --quiet "--pretty=format:%h %f" "$chash") ||
-        { error "failed git show $chash"; return 1; }
+    out=$(gitcmd show --abbrev=8 --quiet "--pretty=format:%h %f" "$chash")
 
     shash=${out% *}
     sname=${out#* }
@@ -164,8 +164,7 @@ apply_one_cherry_pick() {
         fi
     fi
 
-    git format-patch --stdout -1 "$chash" > "$fpath" ||
-        { error "failed git format-patch -1 $chash > $fpath"; return 1; }
+    gitcmd format-patch --stdout -1 "$chash" > "$fpath"
 
     echo "$fname" >> "$series" ||
         { error "failed to write to $series"; return 1; }
@@ -193,7 +192,7 @@ apply_one_cherry_pick() {
 
     local commit_files=""
     commit_files=( "$series" "$fpath" )
-    git diff HEAD "${commit_files[@]}"
+    gitcmd diff HEAD "${commit_files[@]}"
 
     echo -n "Commit this change? (Y/n): "
     read answer || fail "failed to read answer"
@@ -203,16 +202,12 @@ apply_one_cherry_pick() {
 
     bugs=$(git_log_to_dch print_bugs < "$fpath")
     msg="cherry pick $shash${bugs:+${CR}${CR}LP: ${bugs}}"
-    git add "$series" "$fpath" ||
-        { error "failed to git add $series $fpath"; return 1; }
+    gitcmd add "$series" "$fpath"
 
-    git commit -m "$msg" "${commit_files[@]}" ||
-        fail "failed to commit '$msg'"
-    local_cpickhash=$(git show --quiet "--pretty=format:%H") ||
-        { error "failed git show most recent commit"; return 1; }
+    gitcmd commit -m "$msg" "${commit_files[@]}"
+    local_cpickhash=$(gitcmd show --quiet "--pretty=format:%H")
 
-    git commit -m "update changelog" debian/changelog ||
-        fail "failed to commit update to debian changelog."
+    gitcmd commit -m "update changelog" debian/changelog
     drop_cherry_pick_from_daily_branch ${local_cpickhash} ${daily_remote}
 
     return 0
@@ -234,7 +229,7 @@ main() {
         case "$cur" in
             -h|--help) Usage ; exit 0;;
             -d|--daily-remote) DAILY_REMOTE=${next}; shift;;
-            -v|--verbose) VERBOSITY=$((${VERBOSITY}+1)); set -x;;
+            -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             --) shift; break;;
         esac
         shift;

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -107,7 +107,7 @@ NEW_VERSION=""
 
 drop_cherry_pick_from_daily_branch() {
     local local_cpick_commit="$1" daily_remote="${2-origin}"
-    cur_br=$(git branch --show-current)
+    cur_br=$(gitcmd branch --show-current)
     daily_br=${cur_br/ubuntu/ubuntu\/daily}
     gitcmd fetch ${daily_remote}
     echo "Backing out cherry-pick from ${daily_br} branch"
@@ -128,7 +128,7 @@ drop_cherry_pick_from_daily_branch() {
 apply_one_cherry_pick() {
     local r="" commit_in="$1" daily_remote="$2" chash="" shash="" sname=""
     local fname="" cur_br=""
-    cur_br=$(gitcmd rev-parse --abbrev-ref HEAD)
+    cur_br=$(git branch --show-current)
     chash=$(gitcmd show --quiet "--pretty=format:%H" "${commit_in}")
 
     if git merge-base --is-ancestor "$chash" HEAD; then

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -10,8 +10,6 @@ fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
 
 PKG_NAME=$(dpkg-parsechangelog --show-field Source) ||
     fail "failed to read Source from changelog"
-CHERRY_PICK_DATA=debian/${PKG_NAME}-cherry-picks
-RECIPE_FIX_COMMIT=debian/${PKG_NAME}-cherry-pick-recipe-fix
 
 Usage() {
     cat <<EOF
@@ -108,8 +106,8 @@ run_quilt() {
 NEW_VERSION=""
 
 drop_cherry_pick_from_daily_branch() {
-    local local_cpick_commit="$1" daily_remote="$2"
-    cur_br=$(gitcmd rev-parse --abbrev-ref HEAD)
+    local local_cpick_commit="$1" daily_remote="${2-origin}"
+    cur_br=$(git branch --show-current)
     daily_br=${cur_br/ubuntu/ubuntu\/daily}
     gitcmd fetch ${daily_remote}
     echo "Backing out cherry-pick from ${daily_br} branch"
@@ -122,9 +120,7 @@ drop_cherry_pick_from_daily_branch() {
     fi
     gitcmd reset --hard ${cur_br}
 
-    for cpick in `tac ${CHERRY_PICK_DATA}`; do
-        gitcmd revert ${cpick}
-    done
+    gitcmd log --oneline -- debian/patches/*cpick* | cut -d" " -f1 | xargs git revert
     # switch back to current development branch
     gitcmd checkout ${cur_br}
 }
@@ -209,11 +205,6 @@ apply_one_cherry_pick() {
     gitcmd add "$series" "$fpath"
 
     gitcmd commit -m "$msg" "${commit_files[@]}"
-    local_cpickhash=$(gitcmd show --quiet "--pretty=format:%H")
-    echo $local_cpickhash >> ${CHERRY_PICK_DATA}
-    gitcmd add ${CHERRY_PICK_DATA}
-    gitcmd commit -m "Append cpick to ${CHERRY_PICK_DATA}" ${CHERRY_PICK_DATA}
-
     gitcmd commit -m "update changelog" debian/changelog
     drop_cherry_pick_from_daily_branch ${daily_remote}
 

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -4,8 +4,14 @@ VERBOSITY=0
 TEMP_D=""
 CR=$'\n'
 
+
 error() { echo "$@" 1>&2; }
 fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
+
+PKG_NAME=$(dpkg-parsechangelog --show-field Source) ||
+    fail "failed to read Source from changelog"
+CHERRY_PICK_DATA=debian/${PKG_NAME}-cherry-picks
+RECIPE_FIX_COMMIT=debian/${PKG_NAME}-cherry-pick-recipe-fix
 
 Usage() {
     cat <<EOF
@@ -15,7 +21,10 @@ Usage: ${0##*/} [ options ] <<ARGUMENTS>>
    Useful to grab an upstream commit to the current packaging branch.
 
    options:
-      -h | --help  show help
+      -h | --help          show help
+      -d | --daily-remote  the remote from which to checkout the daily branch.
+                           Default: origin
+      -v | --verbose       increase verbosity
 EOF
 }
 
@@ -92,35 +101,32 @@ run_quilt() {
         quilt --quiltrc - "$@"
 }
 
-main() {
-    local short_opts="ho:v"
-    local long_opts="help,verbose"
-    local getopt_out=""
-    getopt_out=$(getopt --name "${0##*/}" \
-        --options "${short_opts}" --long "${long_opts}" -- "$@") &&
-        eval set -- "${getopt_out}" ||
-        { bad_Usage; return; }
+NEW_VERSION=""
 
-    local cur="" next=""
+drop_cherry_pick_from_daily_branch() {
+    local local_cpick_commit="$1" daily_remote="$2"
+    cur_br=$(git rev-parse --abbrev-ref HEAD) ||
+        { error "failed to get current branch name"; return 1; }
+    daily_br=${cur_br/ubuntu/ubuntu\/daily}
+    git fetch ${daily_remote}
+    echo "Backing out cherry-pick from ${daily_br} branch"
+    if [ $(git show-ref refs/heads/${daily_br}) ]; then
+        # Branch already exists so refresh it to remote/ubuntu/daily/<series>
+        git checkout ${daily_br}
+        git reset --hard ${daily_remote}/${daily_br}
+    else
+        # Create local checkout for daily branch
+        git checkout ${daily_remote}/${daily_br} -b ${daily_br}
+    fi
+    git cherry-pick ${local_cpick_commit}
+    git revert ${local_cpick_commit}
+    # switch back to current development branch
+    git checkout ${cur_br}
+}
 
-    while [ $# -ne 0 ]; do
-        cur="$1"; next="$2";
-        case "$cur" in
-            -h|--help) Usage ; exit 0;;
-            -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
-            --) shift; break;;
-        esac
-        shift;
-    done
-
-	[ -n "$TEMP_D" ] ||
-        TEMP_D=$(mktemp -d "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") ||
-		{ error "failed to make tempdir"; return 1; }
-	trap cleanup EXIT
-
-    [ $# -gt 0 ] || { bad_Usage "must provide commit-ish"; return; }
-
-    local r="" commit_in="$1" chash="" shash="" sname="" fname="" cur_br=""
+apply_one_cherry_pick() {
+    local r="" commit_in="$1" daily_remote="$2" chash="" shash="" sname=""
+    local fname="" cur_br=""
     cur_br=$(git rev-parse --abbrev-ref HEAD) ||
         { error "failed to get current branch"; return 1; }
     chash=$(git show --quiet "--pretty=format:%H" "${commit_in}") ||
@@ -172,7 +178,12 @@ main() {
     local message=""
     message=$(git_log_to_dch < "$fpath") ||
         { error "failed getting log entry from $fpath"; return 1; }
-    dch -i "cherry-pick $shash: $message"
+
+    if [ -z "${NEW_VERSION}" ]; then
+        dch -i "cherry-pick $shash: $message"
+    else
+        dch --newversion ${NEW_VERSION} -m "cherry-pick $shash: $message"
+    fi
 
     dch -e || {
         r=$?;
@@ -197,9 +208,45 @@ main() {
 
     git commit -m "$msg" "${commit_files[@]}" ||
         fail "failed to commit '$msg'"
+    local_cpickhash=$(git show --quiet "--pretty=format:%H") ||
+        { error "failed git show most recent commit"; return 1; }
 
     git commit -m "update changelog" debian/changelog ||
         fail "failed to commit update to debian changelog."
+    drop_cherry_pick_from_daily_branch ${local_cpickhash} ${daily_remote}
+
+    return 0
+}
+
+main() {
+    local short_opts="hd:v"
+    local long_opts="help,daily-remote:,verbose"
+    local getopt_out=""
+    getopt_out=$(getopt --name "${0##*/}" \
+        --options "${short_opts}" --long "${long_opts}" -- "$@") &&
+        eval set -- "${getopt_out}" ||
+        { bad_Usage; return; }
+
+    local cur="" next="" DAILY_REMOTE="origin"
+
+    while [ $# -ne 0 ]; do
+        cur="$1"; next="$2";
+        case "$cur" in
+            -h|--help) Usage ; exit 0;;
+            -d|--daily-remote) DAILY_REMOTE=${next}; shift;;
+            -v|--verbose) VERBOSITY=$((${VERBOSITY}+1)); set -x;;
+            --) shift; break;;
+        esac
+        shift;
+    done
+
+	[ -n "$TEMP_D" ] ||
+        TEMP_D=$(mktemp -d "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") ||
+		{ error "failed to make tempdir"; return 1; }
+	trap cleanup EXIT
+
+    [ $# -gt 0 ] || { bad_Usage "must provide commit-ish"; return; }
+    apply_one_cherry_pick $1 ${DAILY_REMOTE}
 
     return 0
 }

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -116,13 +116,15 @@ drop_cherry_pick_from_daily_branch() {
     if [ ! -z "$(gitcmd show-ref refs/heads/${daily_br})" ]; then
         # Branch already exists so refresh it to remote/ubuntu/daily/<series>
         gitcmd checkout ${daily_br}
-        gitcmd reset --hard ${daily_remote}/${daily_br}
     else
         # Create local checkout for daily branch
         gitcmd checkout ${daily_remote}/${daily_br} -b ${daily_br}
     fi
-    gitcmd cherry-pick ${local_cpick_commit}
-    gitcmd revert ${local_cpick_commit}
+    gitcmd reset --hard ${cur_br}
+
+    for cpick in `tac ${CHERRY_PICK_DATA}`; do
+        gitcmd revert ${cpick}
+    done
     # switch back to current development branch
     gitcmd checkout ${cur_br}
 }
@@ -208,9 +210,12 @@ apply_one_cherry_pick() {
 
     gitcmd commit -m "$msg" "${commit_files[@]}"
     local_cpickhash=$(gitcmd show --quiet "--pretty=format:%H")
+    echo $local_cpickhash >> ${CHERRY_PICK_DATA}
+    gitcmd add ${CHERRY_PICK_DATA}
+    gitcmd commit -m "Append cpick to ${CHERRY_PICK_DATA}" ${CHERRY_PICK_DATA}
 
     gitcmd commit -m "update changelog" debian/changelog
-    drop_cherry_pick_from_daily_branch ${local_cpickhash} ${daily_remote}
+    drop_cherry_pick_from_daily_branch ${daily_remote}
 
     return 0
 }

--- a/scripts/cherry-pick
+++ b/scripts/cherry-pick
@@ -179,9 +179,11 @@ apply_one_cherry_pick() {
         { error "failed getting log entry from $fpath"; return 1; }
 
     if [ -z "${NEW_VERSION}" ]; then
-        dch -i "cherry-pick $shash: $message"
+        dch -i "cherry-pick $shash: $message" ||
+            fail "Failed to update changelog"
     else
-        dch --newversion ${NEW_VERSION} -m "cherry-pick $shash: $message"
+        dch --newversion ${NEW_VERSION} -m "cherry-pick $shash: $message" ||
+            fail "Failed to update changelog"
     fi
 
     dch -e || {

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -300,7 +300,8 @@ main() {
         drops=""
         while read bname extra; do
             case "$bname" in
-                cpick-*)
+                fix-cpick-* | cpick-*)
+                    commit=${bname#fix-cpick-}
                     commit=${bname#cpick-}
                     commit=${commit%%-*}
                     echo "bname=$bname commit=${commit}" 1>&2


### PR DESCRIPTION
Add cherry-pick --daily-remote param to specify a remote from which to
git pull ubuntu/daily/$release branches during update.

Each time a cherry-pick is performed on an ubuntu/$release branch,
cherry-pick will do the following:
 * create a debian/patches/cpick-* file from a git cherry-pick of an upstream commoit
 * increment debian/changelog
 * checkout a local branch ubuntu/daily/$release from --daily-remote
 * git reset --hard ubuntu/$release  # to reset ubuntu/daily/$release to tip of ubuntu/$release
 * git revert all local debian/patches/*cpick* commits from ubuntu/daily/$release

Also in this branch:
 * new-upstream-snapshot will also drop any debian/patches/fix-cpick-* files during
    an upstream release

Testing instructions:
  1. checkout origin/ubuntu/devel which already has released cherry picks applied
  2. cherry-pick 32338f57f8b6160ba9758e76b95731a06d5bc2fd  # doc fix
  3. git diff ubuntu/daily/devel # to see that all ubuntu/devel cpicks are reverted from ubuntu/daily/devel
  4. git checkout master
  5. git merge ubuntu/devel
  6. git merge ubuntu/daily/devel 
  7. ls debian/patches   # should not exist
  8.git checkout ubuntu/devel 
  9. new-upstream-snapshot -v   # make sure new upstream snapshots don't fail