### PR TITLE
new-upstream-snapshot: also drop debian/patches/fix-cpick-*

### DIFF
--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -157,10 +157,10 @@ This is generally needed when we are disabling backported feature from tip
 in order to retain existing behavior on an older series.
 
 **Note:** If adding a quilt patch to modify functionality introduced by
-a debian/patches/cpick-\* file, the new quilt patch needs the prefix
-fix-cpick-<previous_cpick_filename> because new-upstream-snapshot removes all
-cpick-\* and fix-cpick-\* files from debian/patches directory. Those patches
-are already considered "applied" in the snapshot we are syncing.
+a debian/patches/cpick-\* file, the new quilt patch should have the prefix
+fix-cpick-<the_ancestor_commitish_for_the_fixed_cpick>. `new-upstream-snapshot` removes all `cpick-<hash>-\*` and fix-cpick-<hash>-\*` files from the
+`debian/patches` directory when the <hash> commit is already applied to the
+commit history of the snapshot.
 
 The procedure is as follows:
 

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -156,6 +156,12 @@ build-now.
 This is generally needed when we are disabling backported feature from tip
 in order to retain existing behavior on an older series.
 
+**Note:** If adding a quilt patch to modify functionality introduced by
+a debian/patches/cpick-\* file, the new quilt patch needs the prefix
+fix-cpick-<previous_cpick_filename> because new-upstream-snapshot removes all
+cpick-\* and fix-cpick-\* files from debian/patches directory. Those patches
+are already considered "applied" in the snapshot we are syncing.
+
 The procedure is as follows:
 
  * quilt push -a                            # Apply existing patches in order

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -300,8 +300,9 @@ main() {
         drops=""
         while read bname extra; do
             case "$bname" in
-                cpick-*)
-                    commit=${bname#cpick-}
+                fix-cpick-* | cpick-*)
+                    commit=${bname#fix-cpick-}
+                    commit=${commit#cpick-}
                     commit=${commit%%-*}
                     echo "bname=$bname commit=${commit}" 1>&2
                     if git merge-base --is-ancestor "$commit" "$from_ref"; then


### PR DESCRIPTION
new-upstream-snapshot drops both debian/patches/cpick-* and fix-cpick-* files
because both are considered patches which are already applied in tip of master.