### PR TITLE
scripts: fix-daily-branch script reverts cpick patches from a source

### DIFF
--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -120,7 +120,7 @@ This is generally not the mechanism that is preferred for any release supported 
 #### Cherry-pick Process
 The tool for doing this is in ``uss-tableflip/scripts/cherry-pick``.  It takes as import a commit-ish that it will create a cherry-pick from.
 
-    $ git checkout origin/ubuntu/xenial -b ubuntu/xenial
+    $ git checkout ubuntu/xenial
     $ cherry-pick dc2bd79949
 
 The tool will:

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -145,8 +145,9 @@ To cherry-pick:
     $ git checkout ubuntu/xenial  # or whatever release.
     $ new-upstream-snapshot -v --update-patches-only
     $ fix-daily-recipe -s ubuntu/xenial -d ubuntu/daily/xenial
-    # Create a PR in github for merging <your_remote>/ubuntu/xenial into canonical/ubuntu/dail
-    # Once that PR is approved
+    # Create a PR in github for merging <your_remote>/ubuntu/xenial into
+    # canonical/ubuntu/xenial
+    # Once that ubuntu/xenial PR is approved, push from git cmdline not Github
     $ git push upstream HEAD
 
     # create local ubuntu/daily/xenial branch with *cpick* reverts to fix daily

--- a/doc/ubuntu_release_process.md
+++ b/doc/ubuntu_release_process.md
@@ -151,7 +151,7 @@ To cherry-pick:
     $ git push upstream HEAD
 
     # create local ubuntu/daily/xenial branch with *cpick* reverts to fix daily
-    $ fix-daily-branch -s ubuntu/xenial -d ubuntu/daily/xenial
+    $ fix-daily-branch xenial upstream
     $ git push upstream ubuntu/daily/xenial  --force
 
 The `cherry-pick` will produce 1 or 2 commits on the branch with summary like:

--- a/scripts/fix-daily-branch
+++ b/scripts/fix-daily-branch
@@ -56,24 +56,10 @@ EOF
 }
 
 main() {
-    local short_opts="h"
-    local long_opts="help"
-    local getopt_out=""
-    getopt_out=$(getopt --name "${0##*/}" \
-        --options "${short_opts}" --long "${long_opts}" -- "$@") &&
-        eval set -- "${getopt_out}" ||
-        { Usage; return; }
-
-    local cur="" next="" release="_unset" remote="_unset"
-
-    while [ $# -ne 0 ]; do
-        cur="$1"; next="$2";
-        case "$cur" in
-            -h|--help) Usage ; exit 0;;
-            --) shift; break;;
-        esac
-        shift;
-    done
+    if [ "$1" = "--help" -o "$1" = "-h" ]; then
+        Usage
+        exit 0
+    fi
     [ $# -eq 2 ] || { bad_Usage "provide both <release> and <remote>"; return; }
     release=$1
     remote=$2

--- a/scripts/fix-daily-branch
+++ b/scripts/fix-daily-branch
@@ -15,26 +15,29 @@ gitcmd() {
 
 Usage() {
 cat <<EOF
-${0##*/}
+Usage: ${0##*/} release remote
 
-Create a daily_branch which reverts any debian/patches/*cpick* commits from
-source_branch.
+Create a daily branch which reverts any debian/patches/*cpick* commits from
+a ubuntu/release branch.
 
 options:
-   -h|--help                   show this message.
-   --source-branch          The local branch name from which to revert all
-                            debian/patches/*cpick* files. Default: ubuntu/devel.
-   --daily-branch           The local daily branch name to create which reverts
-                            debian/patches/*cpick* files. Default:
-                            ubuntu/daily/devel
+   -h|--help    show this message.
+   release      The Ubuntu release name. For example: xenial 
+   remote       The git remote from which to pull and push release
+                branches. For example: upstream
+
 EOF
 }
+bad_Usage() { Usage 1>&2; [ $# -eq 0 ] || error "$@"; return 1; }
 
 drop_cherry_picks_from_daily_branch() {
-    local source_branch="${1}" daily_branch="${2}" daily_remote="${3:-origin}"
-    gitcmd fetch ${daily_remote}
+    local release="${1}" remote="${2}"
+    local source_branch="${remote}/ubuntu/${release}"
+    local daily_branch="ubuntu/daily/${release}"
+
+    gitcmd fetch ${remote}
     echo "Backing out all debian/patches/*cpick* from ${daily_branch} branch"
-    if git branch | grep -q ${daily_branch}; then
+    if gitcmd branch | grep -q ${daily_branch}; then
         gitcmd checkout ${daily_branch}
     else
         # Create local daily branch from current
@@ -43,41 +46,39 @@ drop_cherry_picks_from_daily_branch() {
     gitcmd reset --hard ${source_branch}
     gitcmd log --oneline -- debian/patches/*cpick* | cut -d" " -f1 | xargs git revert
     # switch back to current development branch
-    gitcmd checkout ${source_branch}
     cat <<EOF
 To fix daily recipe builds perform the following:
 
-  # Verify local changes in $daily_branch versus $source_branch
-  git diff $daily_branch
-  git push $daily_remote $daily_branch
+    # Verify local changes in $daily_branch versus $source_branch
+    git diff ${source_branch}
+    git push ${remote} ${daily_branch}
 EOF
 }
 
 main() {
-    local short_opts="hd:s:r:"
-    local long_opts="help,daily-branch:,source_branch:,remote:"
+    local short_opts="h"
+    local long_opts="help"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
         eval set -- "${getopt_out}" ||
         { Usage; return; }
 
-    local cur="" next="" daily_branch="ubuntu/daily/devel"
-    local source_branch="ubuntu/devel" remote="origin"
+    local cur="" next="" release="_unset" remote="_unset"
 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
         case "$cur" in
             -h|--help) Usage ; exit 0;;
-            -d|--daily-branch) daily_branch=$next; shift;;
-            -r|--remote) remote=$next; shift;;
-            -s|--source-branch) source_branch=$next; shift;;
             --) shift; break;;
         esac
         shift;
     done
+    [ $# -eq 2 ] || { bad_Usage "provide both <release> and <remote>"; return; }
+    release=$1
+    remote=$2
 
-    drop_cherry_picks_from_daily_branch $source_branch $daily_branch $remote
+    drop_cherry_picks_from_daily_branch $release $remote
 }
 
 main "$@"

--- a/scripts/fix-daily-branch
+++ b/scripts/fix-daily-branch
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Fix daily build branches so daily build recipes by dropping all 'cherry-pick'
+# quilt patches applied to a given ubuntu/* release branch.
+#  Any *cpick* files in debian/patches are git revert'd in reverse order
+# so that the upstream commits the *cpick* file represent are able to apply.
+set -e
+
+error() { echo "$@" 1>&2; }
+fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
+
+gitcmd() {
+    git "$@" || fail "Failed running git $@"
+}
+
+Usage() {
+cat <<EOF
+${0##*/}
+
+Create a daily_branch which reverts any debian/patches/*cpick* commits from
+source_branch.
+
+options:
+   -h|--help                   show this message.
+   --source-branch          The local branch name from which to revert all
+                            debian/patches/*cpick* files. Default: ubuntu/devel.
+   --daily-branch           The local daily branch name to create which reverts
+                            debian/patches/*cpick* files. Default:
+                            ubuntu/daily/devel
+EOF
+}
+
+drop_cherry_picks_from_daily_branch() {
+    local source_branch="${1}" daily_branch="${2}" daily_remote="${3:-origin}"
+    gitcmd fetch ${daily_remote}
+    echo "Backing out all debian/patches/*cpick* from ${daily_branch} branch"
+    if git branch | grep -q ${daily_branch}; then
+        gitcmd checkout ${daily_branch}
+    else
+        # Create local daily branch from current
+        gitcmd checkout ${source_branch} -b ${daily_branch}
+    fi
+    gitcmd reset --hard ${source_branch}
+    gitcmd log --oneline -- debian/patches/*cpick* | cut -d" " -f1 | xargs git revert
+    # switch back to current development branch
+    gitcmd checkout ${source_branch}
+    cat <<EOF
+To fix daily recipe builds perform the following:
+
+  # Verify local changes in $daily_branch versus $source_branch
+  git diff $daily_branch
+  git push $daily_remote $daily_branch
+EOF
+}
+
+main() {
+    local short_opts="hd:s:r:"
+    local long_opts="help,daily-branch:,source_branch:,remote:"
+    local getopt_out=""
+    getopt_out=$(getopt --name "${0##*/}" \
+        --options "${short_opts}" --long "${long_opts}" -- "$@") &&
+        eval set -- "${getopt_out}" ||
+        { Usage; return; }
+
+    local cur="" next="" daily_branch="ubuntu/daily/devel"
+    local source_branch="ubuntu/devel" remote="origin"
+
+    while [ $# -ne 0 ]; do
+        cur="$1"; next="$2";
+        case "$cur" in
+            -h|--help) Usage ; exit 0;;
+            -d|--daily-branch) daily_branch=$next; shift;;
+            -r|--remote) remote=$next; shift;;
+            -s|--source-branch) source_branch=$next; shift;;
+            --) shift; break;;
+        esac
+        shift;
+    done
+
+    drop_cherry_picks_from_daily_branch $source_branch $daily_branch $remote
+}
+
+main "$@"
+
+# vi: ts=4 expandtab

--- a/scripts/fix-daily-branch
+++ b/scripts/fix-daily-branch
@@ -37,13 +37,7 @@ drop_cherry_picks_from_daily_branch() {
 
     gitcmd fetch ${remote}
     echo "Backing out all debian/patches/*cpick* from ${daily_branch} branch"
-    if gitcmd branch | grep -q ${daily_branch}; then
-        gitcmd checkout ${daily_branch}
-    else
-        # Create local daily branch from current
-        gitcmd checkout ${source_branch} -b ${daily_branch}
-    fi
-    gitcmd reset --hard ${source_branch}
+    gitcmd checkout -B ${daily_branch} ${source_branch}
     gitcmd log --oneline -- debian/patches/*cpick* | cut -d" " -f1 | xargs git revert
     # switch back to current development branch
     cat <<EOF


### PR DESCRIPTION
Provide a local source_branch from which to revert all
debian/patches/*cpick*  quilt patches.

This script is performed after each uss-tableflip/scripts/cherry-pick
which added new debian/patches/*cpick* in order to allow build recipe
to merge ubuntu/$release and ubuntu/daily/$release into master before
building a daily package.


To test:
```
cd /tmp
git clone git@github.com:canonical/cloud-init.git
cd cloud-init
# ubuntu/daily/focal is currently broken and doesn't merge, see the failure to  merge
git merge origin/ubuntu/focal
git merge origin/ubuntu/daily/focal

# fix it
fix-daily-branch -s ubuntu/focal -d ubuntu/daily/focal
git checkout master
git reset --hard origin/master
git merge origin/ubuntu/focal
git merge ubuntu/daily/focal
ls debian/patches # expect none
```