### PR TITLE
new-upstream-snapshot: use distro-info to determine pkg version suffix

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Update current branch with commitish from master
+
 ORIG_TIP=""
 TEMP_D=""
 VERBOSITY=0
@@ -172,6 +174,8 @@ main() {
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
     local update_patches_only=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
+    which distro-info || fail "Please apt-get install distro-info"
+
     local cur="" next="" 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
@@ -243,14 +247,11 @@ main() {
         fail "failed to read Source from changelog"
     dist=$(dpkg-parsechangelog --show-field Distribution)
 
+    # If we fail to find --series X it is because it is a devel release
+    # so set sru_ver_suff empty because we don't provide suffix on devel
     sru_ver_suff=$(distro-info --series ${cur_branch#ubuntu/} --release |
-                       awk '{printf("~%s.1", $1)}') ||
-        echo "Warning: missing distro-info package"
+                       awk '{printf("~%s.1", $1)}') || sru_ver_suff=""
 
-    if [ -z "sru_ver_suff" ]; then
-        sru_ver_suff=$(echo "$prev_pkg_ver" |
-            sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
-    fi
     [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
 
     local sru_bug_string="" skip_bugs=""

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -35,6 +35,8 @@ options:
                                   refreshing patches in debian/patches/
       --skip-release              Sync upstream commits, but avoid SRU_BUG
                                   checks as this release will not be published
+      --target-release            Optionally override the Ubuntu release
+                                  detected from debian/changelog. Example: focal
       --sru-bug                   the bug number to add to the debian/changelog
       --no-bugs                   do not put bug refs (LP: #XXX) in changelog.
    -v|--verbose                  increase verbosity.
@@ -163,9 +165,36 @@ is_merge_commit() {
     [ $num -gt 1 ]
 }
 
+
+
+find_sru_ver_suff() {
+    # target_release is like 'bionic' or 'groovy'
+    local target_release="$1" devel_release=""
+
+    command -v ubuntu-distro-info > /dev/null 2>&1 ||
+        fail "Missing distro-info: apt-get install distro-info"
+
+    devel_release=$(ubuntu-distro-info --devel) ||
+        fail "could not get distro-info --devel"
+
+    if [ "${target_release}" = "${devel_release}" ]; then
+        # Don't provide suffix for devel release
+        echo ""
+        return 0
+    fi
+
+    if ! ubuntu-distro-info --supported | grep -q "^$target_release$"; then
+        fail "Unsuppported distro: $target_release"
+    fi
+
+    echo $(ubuntu-distro-info --series=${target_release} --release |
+                       awk '{printf("~%s.1", $1)}')
+    return 0
+}
+
 main() {
     local short_opts="hv"
-    local long_opts="help,update-patches-only,no-bugs,skip-branch-name-check,skip-release,sru-bug,verbose"
+    local long_opts="help,update-patches-only,no-bugs,skip-branch-name-check,skip-release,sru-bug,target-release:,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -173,8 +202,7 @@ main() {
         { Usage; return; }
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
     local update_patches_only=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
-
-    which distro-info || fail "Please apt-get install distro-info"
+    local target_release=""
 
     local cur="" next="" 
     while [ $# -ne 0 ]; do
@@ -183,6 +211,7 @@ main() {
             -h|--help) Usage ; exit 0;;
                --skip-branch-name-check) skip_branch_name_check=1;;
                --skip-release) skip_release=true;;
+               --target-release) target_release=$2; shift;;
                --update-patches-only) update_patches_only=true;;
                --sru-bug) sru_bug_fillstr=$3; shift;;
                --no-bugs) bug_refs_in_clog=false;;
@@ -226,14 +255,20 @@ main() {
     ORIG_TIP=$(git rev-parse HEAD) ||
         fail "failed to get current tip"
 
-    if [ "${skip_branch_name_check}" = "0" ]; then
+    if [ "${skip_branch_name_check}" = "0" -a -z "${target_release}" ]; then
         case "$cur_branch" in
             ubuntu/*) :;;
             *)
                 error "On branch '$cur_branch', expect to be on ubuntu/*"
-                error "Skip check with --skip-branch-name-check or"
-                error "  SKIP_BRANCH_NAME_CHECK=1"
-                fail;;
+
+                if [ "${cur_branch#ubuntu}" = "${cur_branch}" ]; then
+                    error "Either skip check with either:"
+                    error " --skip-branch-name-check,"
+                    error " SKIP_BRANCH_NAME_CHECK=1 or"
+                    error " --target-release=<release_name>"
+                    fail
+                fi
+                ;;
         esac
     fi
 
@@ -263,19 +298,14 @@ main() {
     debug 1 "prev_released_pkg_ver=$prev_released_pkg_ver"
     debug 1 "unreleased=${unreleased_changes}"
 
-    # If we fail to find --series X it is because it is a devel release
-    # so set sru_ver_suff empty because we don't provide suffix on devel
-    devel_dist=$(distro-info --devel) ||
-        fail "distro-info out of date: apt install distro-info"
 
-    if [ "${prev_dist}" != "${devel_dist}" ]; then
-        sru_ver_suff=$(distro-info --series ${prev_dist} --release |
-                           awk '{printf("~%s.1", $1)}') || sru_ver_suff=""
-    fi
 
-    [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
+    local sru_bug_string="" skip_bugs="" sru_ver_suff=""
 
-    local sru_bug_string="" skip_bugs=""
+    # --target-release overrides detected prev_dist
+    [ -z "${target_release}" ] && target_release="${prev_dist}"
+    sru_ver_suff=$(find_sru_ver_suff "${target_release}")
+
     [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"
     if [ -n "$sru_ver_suff" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
@@ -490,7 +520,7 @@ main() {
         # with a message like: Uploads aren't permitted to pocket: proposed
         release_suffix="-proposed"
     else
-        prev_dist=${prev_dist%-proposed}
+        target_release=${target_release%-proposed}
     fi
     echo wrote new-upstream-changes.txt for $pkg_name version ${new_pkg_ver}.
     if [ "${skip_release}" = "true" ]; then
@@ -502,7 +532,7 @@ EOF
     else
         cat <<EOF
 release with:
-sed -i -e "1s/UNRELEASED/${prev_dist}${release_suffix}/" debian/changelog
+sed -i -e "1s/UNRELEASED/${target_release}${release_suffix}/" debian/changelog
 git commit -m "releasing $pkg_name version $new_pkg_ver" debian/changelog
 git tag $tag
 # optionally push your tag: git push <remote> $tag

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -243,9 +243,14 @@ main() {
         fail "failed to read Source from changelog"
     dist=$(dpkg-parsechangelog --show-field Distribution)
 
-    # if present, pull the '~16.04.x' off of the previous entry.
-    sru_ver_suff=$(echo "$prev_pkg_ver" |
-        sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
+    sru_ver_suff=$(distro-info --series ${cur_branch#ubuntu/} --release |
+                       awk '{printf("~%s.1", $1)}') ||
+        echo "Warning: missing distro-info package"
+
+    if [ -z "sru_ver_suff" ]; then
+        sru_ver_suff=$(echo "$prev_pkg_ver" |
+            sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
+    fi
     [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
 
     local sru_bug_string="" skip_bugs=""

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -247,9 +247,25 @@ main() {
         fail "failed to read Source from changelog"
     dist=$(dpkg-parsechangelog --show-field Distribution)
 
+    local prev_released_pkg_ver="" unreleased_changes="" prev_dist=""
+    if [ "$dist" = "UNRELEASED" ]; then
+        prev_released_pkg_ver=$(
+            dpkg-parsechangelog --offset 1 --count=1 --show-field Version)
+        unreleased_changes=$(
+            dpkg-parsechangelog --count=1 --show-field Changes | tail -n +4)
+        prev_dist=$(
+            dpkg-parsechangelog --offset 1 --count=1 --show-field Distribution)
+    else
+        prev_released_pkg_ver="${prev_pkg_ver}"
+        prev_dist="$dist"
+    fi
+
+    debug 1 "prev_released_pkg_ver=$prev_released_pkg_ver"
+    debug 1 "unreleased=${unreleased_changes}"
+
     # If we fail to find --series X it is because it is a devel release
     # so set sru_ver_suff empty because we don't provide suffix on devel
-    sru_ver_suff=$(distro-info --series ${cur_branch#ubuntu/} --release |
+    sru_ver_suff=$(distro-info --series ${prev_dist} --release |
                        awk '{printf("~%s.1", $1)}') || sru_ver_suff=""
 
     [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
@@ -284,21 +300,6 @@ main() {
         exit 0
     fi
 
-    local prev_released_pkg_ver="" unreleased_changes="" prev_dist=""
-    if [ "$dist" = "UNRELEASED" ]; then
-        prev_released_pkg_ver=$(
-            dpkg-parsechangelog --offset 1 --count=1 --show-field Version)
-        unreleased_changes=$(
-            dpkg-parsechangelog --count=1 --show-field Changes | tail -n +4)
-        prev_dist=$(
-            dpkg-parsechangelog --offset 1 --count=1 --show-field Distribution)
-    else
-        prev_released_pkg_ver="${prev_pkg_ver}"
-        prev_dist="$dist"
-    fi
-
-    debug 1 "prev_released_pkg_ver=$prev_released_pkg_ver"
-    debug 1 "unreleased=${unreleased_changes}"
 
     local dpseries="debian/patches/series" drops=""
     local msg="" extra="" bname=""

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -265,8 +265,13 @@ main() {
 
     # If we fail to find --series X it is because it is a devel release
     # so set sru_ver_suff empty because we don't provide suffix on devel
-    sru_ver_suff=$(distro-info --series ${prev_dist} --release |
-                       awk '{printf("~%s.1", $1)}') || sru_ver_suff=""
+    devel_dist=$(distro-info --devel) ||
+        fail "distro-info out of date: apt install distro-info"
+
+    if [ "${prev_dist}" != "${devel_dist}" ]; then
+        sru_ver_suff=$(distro-info --series ${prev_dist} --release |
+                           awk '{printf("~%s.1", $1)}') || sru_ver_suff=""
+    fi
 
     [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
 


### PR DESCRIPTION
distro-info allows us to determine the right pkg version suffix of the
format ~YY.MM.1. Rely on this tool if available.

If missing, print a warning to the console during new-upstream-snapshot
and still rely on previous debian/changelog versions to determine current
suffix.

to test:
```
git checkout upstream/ubuntu/focal -B ubuntu/focal
# bump back the local commit to something that didn't contain a ~20.04.1 in the debian/changelog
git reset --hard ubuntu/19.4-56-g06e324ff-0ubuntu1
new-upstream-snapshot 
# should auto-detect and add a 20.04.1 to the latest debian/changelog package version  stirng
```
Without this change, debian.changelog for focal would not contain a ~20.04.1 suffix and we had to manually add it.