### PR TITLE
build-package: drop unneeded "fixme" comment on extracting debian/

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -205,8 +205,6 @@ main() {
             fail "failed creating $wtd"
 
         # extract upstream tarball, remove it's debian dir, extract ours.
-        # not certain that removal is correct, may be correct to 
-        # just extract our debian over the top.
         tar -C "$wtd" --strip-components=1 -xf "${orig_tarball_fp}" ||
             fail "failed to extract $orig_tarball_fp in $wtd"
         if [ -d "$wtd/debian" ]; then


### PR DESCRIPTION
Per dpkg-source(1) the debian/ directory in the .orig tarball is removed
and replaced with the one from the .debian tarball, so the script is
doing the right thing.

(This is true only for source format 3.0 packages, but build-package
doesn't support non-native 1.0 packages.)