### PR TITLE
new-upstream-snapshot fix bug in --update-patches-only

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -410,7 +410,7 @@ main() {
     fi
 
     if [ "$update_patches_only" = "true" ]; then
-        if [ -z "$drops" -o -z "$refreshed" ]; then
+        if [ -z "$drops" -a -z "$refreshed" ]; then
             error "No patches updated. Nothing to commit."
             return 0
         fi


### PR DESCRIPTION
When invoked with --update-patches-only, the code would showed:

     if [ -z "$drops" -o -z "$refreshed" ]; then
         error "No patches updated. Nothing to commit."
         return 0
     fi

But really if there are drops *or* refreshes, then we have something
to commit. Negative logic (-z) means we need -a here.

Also, if no changes were made, then we were leaving the merge applied.
Rather, if "update-patches-only" with nothing to do should restore
to the original state.
