### PR TITLE
new-upstream-snapshot --update-patches-only: do nothing if nothing to do

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -411,7 +411,9 @@ main() {
 
     if [ "$update_patches_only" = "true" ]; then
         if [ -z "$drops" -a -z "$refreshed" ]; then
-            error "No patches updated. Nothing to commit."
+            error "No patches updated. Nothing to commit. restoring to $ORIG_TIP"
+            git reset --hard "$ORIG_TIP" ||
+                fail "failed to reset back to start commit $ORIG_TIP"
             return 0
         fi
 


### PR DESCRIPTION
if --update-patches had nothing to do, then it would leave the HEAD
set to after the merge.  Rather, if "update-patches-only" with nothing
to do should restore to the original state.