### PR TITLE
new-upstream-snapshot: determine proper version suffix on first SRU

### DIFF
--- a/scripts/log2dch
+++ b/scripts/log2dch
@@ -195,7 +195,13 @@ git_log_to_dch() {
         case "$line" in
             commit\ *)
                 if [ -n "$commit" ]; then
-	            $skip_bugs && bugs=""
+	            if [ $skip_bugs ]; then
+                       bugs=""  # Don't append bugs referenced in commit body
+
+                       # Replace "LP: #" with "LP:" if present in subject
+                       # to avoid trigging SRU validation of bugs
+                       subject=${subject/LP: #/LP:}
+                    fi
                     "$func" "$commit" "$subject" "$author" "$bugs"
                 fi
                 commit=${line#commit }
@@ -209,7 +215,13 @@ git_log_to_dch() {
         esac
     done
     if [ -n "$commit" ]; then
-	$skip_bugs && bugs=""
+	if [ $skip_bugs ]; then
+            bugs=""  # Don't append bugs referenced in commit body
+
+            # Replace "LP: #" with "LP:" if present in subject
+            # to avoid trigging SRU validation of bugs
+            subject=${subject/LP: #/LP:}
+        fi
         $func "$commit" "$subject" "$author" "$bugs"
     fi
 }

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -35,6 +35,9 @@ options:
                                   checks as this release will not be published
       --sru-bug                   the bug number to add to the debian/changelog
       --no-bugs                   do not put bug refs (LP: #XXX) in changelog.
+      --first-sru                 provide this flag when this is the first SRU
+                                  to a series. It will determine the right
+                                  version suffix, prompt for SRU bug.
    -v|--verbose                  increase verbosity.
 EOF
 }
@@ -163,14 +166,14 @@ is_merge_commit() {
 
 main() {
     local short_opts="hv"
-    local long_opts="help,update-patches-only,no-bugs,skip-branch-name-check,skip-release,sru-bug,verbose"
+    local long_opts="help,update-patches-only,no-bugs,first-sru,skip-branch-name-check,skip-release,sru-bug:,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
         eval set -- "${getopt_out}" ||
         { Usage; return; }
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
-    local update_patches_only=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
+    local update_patches_only=false first_sru=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
     local cur="" next="" 
     while [ $# -ne 0 ]; do
@@ -180,13 +183,15 @@ main() {
                --skip-branch-name-check) skip_branch_name_check=1;;
                --skip-release) skip_release=true;;
                --update-patches-only) update_patches_only=true;;
-               --sru-bug) sru_bug_fillstr=$3; shift;;
+               --sru-bug) sru_bug_fillstr=$next; shift;;
                --no-bugs) bug_refs_in_clog=false;;
+               --first-sru) bug_refs_in_clog=false; first_sru=true;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             --) shift; break;;
         esac
         shift;
     done
+
 
     [ $# -eq 0 -o $# -eq 1 ] || {
         Usage "Got $# arguments. expected 0 or 1.";
@@ -243,10 +248,17 @@ main() {
         fail "failed to read Source from changelog"
     dist=$(dpkg-parsechangelog --show-field Distribution)
 
-    # if present, pull the '~16.04.x' off of the previous entry.
-    sru_ver_suff=$(echo "$prev_pkg_ver" |
-        sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
-    [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
+
+    if [ "$first_sru" = "true" ]; then
+        command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
+        # get ~20.10.1 for latest --stable release
+        sru_ver_suff=$(distro-info --stable -r | awk '{printf "~%s.1", $1}')
+    else
+        # if present, pull the '~16.04.x' off of the previous entry.
+        sru_ver_suff=$(echo "$prev_pkg_ver" |
+            sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
+        [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
+    fi
 
     local sru_bug_string="" skip_bugs=""
     [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"


### PR DESCRIPTION
- Add a `--first-sru` parameter to `new-upstream-snapshot` to use `distro-info --stable -r` to determine the proper debian version suffix.

- Correct getopt long_opts parsing of `sru-bug:` to require a value
-  log2dch now replaces "LP: #" with  "LP:" in changelog entries when `--skip-bugs` is provided

Fixes: #69