### PR TITLE
sbuild-it: allow specifying option ppcel or riscv64 or powerpc arch

### DIFF
--- a/scripts/sbuild-it
+++ b/scripts/sbuild-it
@@ -96,7 +96,7 @@ for arg in "$@"; do
                 dsc="$tmp"
             fi
             ;;
-        i386|amd64) arch="$arg";;
+        i386|amd64|ppcel|riscv64|powerpc) arch="$arg";;
         *) fail "confused by $arg";;
     esac
 done


### PR DESCRIPTION
Testable with
```bash
sudo sbuild-launchpad-chroot create \
     --architecture="powerpc" "--name=xenial-powerpc" "--series=xenial"
build-package 
sbuilt-id ../*dsc powerpc
```