### PR TITLE
Update upstream release process (SC-426)

### DIFF
--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -1,6 +1,8 @@
 This covers the cloud-init upstream release process.
 
-This document assumes the Canonical cloud-init remote is named `upstream` whereas your personal fork is named `origin`. For example,
+# Assumptions
+## cloud-init
+cloud-init is assumed to be cloned locally with the Canonical cloud-init remote named `upstream` and your personal fork named `origin`. For example,
 ```bash
 $ git remote -v
 origin	git@github.com:MyGithubName/cloud-init.git (fetch)
@@ -8,8 +10,11 @@ origin	git@github.com:MyGithubName/cloud-init.git (push)
 upstream	git@github.com:canonical/cloud-init.git (fetch)
 upstream	git@github.com:canonical/cloud-init.git (push)
 ```
-
 Adjust any references to `upstream` and `origin` accordingly if yours are different.
+
+## Tools on path
+Some scripts referenced in this guide invoke other tools assumed to be on the PATH, so add `uss-tableflip/scripts` to your PATH.
+Additionally, the `lptools` package should be installed. Use `apt` to install it.
 
 # Pre-release
 ## Send pre-release email to mailing list
@@ -27,7 +32,6 @@ Start creating a process bug in the cloud-init project that captures the new rel
 Use the `upstream-release` script (described in the next section) to generate the bug contents for you.
 
 See [previous release bugs in Launchpad](https://bugs.launchpad.net/cloud-init/+bugs?field.searchtext=Release&orderby=-datecreated&search=Search&field.status%3Alist=FIXRELEASED&field.importance%3Alist=UNDECIDED).
-
 
 ## Create upstream-release branch
 **SAVE ALL LOCAL CHANGES TO A BRANCH**, then
@@ -85,7 +89,6 @@ $ gpg --sign --armor --detach-sig cloud-init-<version>.tar.gz
 ## Create release in Launchpad
 Example of a finished release: https://launchpad.net/cloud-init/trunk/21.3
 ### Option 1: Script
-* Install the lptools package through apt
 * Copy the changelog (for *just* this release) to a file called 'changelog-file'
 * Copy the release notes (not including changelog) from the launchpad bug to a file called 'releasenotes-file'
 ```bash

--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -1,152 +1,163 @@
-# cloud-init upstream release process
-
 This covers the cloud-init upstream release process.
 
-## commit locally, push merge proposal
-The change locally to mark a release should look like previous release
-commits.
+This document assumes the Canonical cloud-init remote is named `upstream` whereas your personal fork is named `origin`. For example,
+```bash
+$ git remote -v
+origin	git@github.com:MyGithubName/cloud-init.git (fetch)
+origin	git@github.com:MyGithubName/cloud-init.git (push)
+upstream	git@github.com:canonical/cloud-init.git (fetch)
+upstream	git@github.com:canonical/cloud-init.git (push)
+```
 
-Examples:
+Adjust any references to `upstream` and `origin` accordingly if yours are different.
 
- * [17.1](https://git.launchpad.net/cloud-init/commit/?id=17.1)
- * [17.2](https://git.launchpad.net/cloud-init/commit/?id=17.1)
- * [20.1](https://git.launchpad.net/cloud-init/commit/?id=20.1)
+# Pre-release
+## Send pre-release email to mailing list
+Send an email to the cloud-init mailing list announcing the upcoming release. See previous emails for examples:
+* https://lists.launchpad.net/cloud-init/msg00357.html
+* https://lists.launchpad.net/cloud-init/msg00335.html
 
-The commit content is obtained with the following:
+## Perform pre-release checks
+* All outstanding merge proposals have been reviewed for merge
+* CI is green
 
- 1. Clone latest cloud-init master branch and run `upstream-release`
-   ```bash
-   cd <cloud-init-root-dir>
-   git checkout master
-   git pull
-   uss-tableflip/scripts/upstream-release <NEW_major_minor> <PREV_major_minor>
-   ```
- 2. You will be prompted with content to file a release process bug in launchpad
-   * Example Bugs:
-   [18.1](https://pad.lv/1751145),
-   [18.2](https://bugs.launchpad.net/bugs/1759318),
-   [19.4](https://pad.lv/1851428)
+## Start upstream release bug
+Start creating a process bug in the cloud-init project that captures the new release version, highlights, and changelog.
 
- 3. Enter the bug you created which will be used in the git commit message on
-    a new local **upstream/X.Y** branch.
+Use the `upstream-release` script (described in the next section) to generate the bug contents for you.
 
-    **Note:** If a branch other than master was used or master is out of date,
-     you will get strange entries in Changelog about cherry pick commits or
-     commits will not match tip of upstream/master.
+See [previous release bugs in Launchpad](https://bugs.launchpad.net/cloud-init/+bugs?field.searchtext=Release&orderby=-datecreated&search=Search&field.status%3Alist=FIXRELEASED&field.importance%3Alist=UNDECIDED).
 
-    **Note:**  At this point, running `tox` locally will fail, complaining
-     that your version does not match what git-describe does.  CI is
-     configured to work around this problem for release branches, so you
-     can disregard these local failures.  (We will create a tag later in
-     the process which fixes this issue.)
 
- 4. Push the branch up for review and create a pull request.  We will
-    use that PR for some documentation on things that have been tested.
-    Example merge proposals:
-    [17.2](https://code.launchpad.net/~smoser/cloud-init/+git/cloud-init/+merge/335233),
-    [18.1](https://code.launchpad.net/~smoser/cloud-init/+git/cloud-init/+merge/338588)
-    [20.1](https://github.com/canonical/cloud-init/pull/222)
+## Create upstream-release branch
+**SAVE ALL LOCAL CHANGES TO A BRANCH**, then
+```bash
+git fetch upstream
+git checkout main
+git reset upstream/main --hard
+```
 
-Once the pull request has been squash merged into master, you can
-proceed.  Ensure that your local master is on that squash-merged commit
-before proceeding.
+Run `uss-tableflip/scripts/upstream-release <release_version> <old_version>` from cloud-init tree with updated main branch.
+The script will:
+* Prompt you to create the bug you created in the previous section (it doesn't create it for you)
+* Generate the contents to be pasted into the bug description. At this point you should finish creating the bug. You can finish the TODO later
+* Prompt you to enter the bug number of the created bug
+* Create a local release branch containing a release commit and an updated changelog
 
-## Update Release info on Launchpad.
-Go to https://launchpad.net/cloud-init click the milestone that we're
-releasing.  That will take you to
-[lp/cloud-init/+milestone/<X.Y>](http://launchpad.net/cloud-init/+milestone/17.2)
-.  Hit 'Create release'.
+**Note:** If a branch other than main was used or main is out of date,
+you will get strange entries in Changelog about cherry pick commits or
+commits will not match tip of upstream/main.
 
- Model the Release notes after other releases such as
- [17.1](https://launchpad.net/cloud-init/+milestone/17.1/) or
- [17.2](https://launchpad.net/cloud-init/+milestone/17.2)
+**Note:**  At this point, running `tox` locally will fail, complaining
+that your version does not match what git-describe does.  CI is
+configured to work around this problem for release branches, so you
+can disregard these local failures.  (We will create a tag later in
+the process which fixes this issue.)
 
-To help get some of those bits of information, add '| wc -l' for just
-the numbers. not done here to have you sanity check output.
+Push the branch up for review and create a pull request.  We will use that PR for some documentation on things that have been tested.
 
-  * just get log into a file
+## Fill in launchpad bug highlights
+Now that your PR is up and ready for review, go back to the launchpad bug you created and fill in the highlights. There's no real formula for this other than a bulleted list of the 5-ish most noteworthy changes this release. Generally this won't include testing or simple bug fixes.
 
-        git log 18.2..HEAD > git-log
-
-  * contributors
-
-        grep Author git-log | sed 's,.*: ,,'  | sort -u
-
-  * top level domains
-
-        grep Author git-log | sed 's,.*: ,,'  | sort -u | sed 's,.*@,,' | sort -u
-
-  * bugs
-
-        grep '^[ ]*LP' git-log | sed -e 's,#,,g' -e 's,.*LP: ,,' -e 's/,[ ]*/\n/'
-
-## Tag and push it to git
-
-First, ensure that you have a clean working tree with the squash-merged
-release commit:
-
-    git checkout master
-    git fetch upstream
-    git reset --hard upstream/master
-
-Then create a signed tag, pointing at the squash-merged release commit:
-
-    git tag --annotate --sign YY.N
-
+## Merge branch and tag
+After getting approval for your release branch, merge the branch to main, then tag (annotated and signed):
+```bash
+$ git tag --annotate --sign -m 'Release <version>' <version>
+```
 Then push it:
+```bash
+$ git push upstream <version>
+```
+Note that if the reviewer merged your branch, they may have tagged it as well, so check the tags before tagging it yourself.
 
-    git push upstream YY.N
+# Upstream Release
+**WAIT UNTIL THE RELEASE BRANCH HAS BEEN MERGED BEFORE PERFORMING THIS SECTION**
 
+## Create release tarball
+Tarball *must* be signed.
+```bash
+$ ./tools/make-tarball
+cloud-init-<version>.tar.gz
 
-## Upload source tarball to Launchpad.
-Then upload that to launchpad.
+$ gpg --sign --armor --detach-sig cloud-init-<version>.tar.gz
+```
 
-    $ ./tools/make-tarball
-    cloud-init-17.2.tar.gz
+## Create release in Launchpad
+Example of a finished release: https://launchpad.net/cloud-init/trunk/21.3
+### Option 1: Script
+* Install the lptools package through apt
+* Copy the changelog (for *just* this release) to a file called 'changelog-file'
+* Copy the release notes (not including changelog) from the launchpad bug to a file called 'releasenotes-file'
+```bash
+$ lp-project-upload cloud-init <version> cloud-init-<version>.tar.gz <NEXT_version> changelog-file releasenotes-file
+```
+Note that `<NEXT_version>` in the command is for specifying our next milestone. So if we're currently releasing 21.3, `<NEXT_version>` would be 21.4.
+### Option 2: Launchpad UI
+Don't do this if you used Option 1 above.
 
-    $ gpg --sign --armor --detach-sig cloud-init-17.2.tar.gz
+Go to https://launchpad.net/cloud-init click the milestone that we're
+releasing.
 
+Hit 'Create release' (Under Milestone information in middle of page)
 
-Note, we can do this step including the 'Update Release info' step with
-with 'lp-project-upload' from 'lptools' package:
+Fill in details:
+* **Don't** keep milestone active
+* Specify current date for 'Date released'
+* Copy the release notes from the bug (minus the changelog) into the 'Release notes' section
+* Copy the changelog from the bug into the 'Changelog' section.
 
+Once we have created our release, we should create the milestone for the next release.
+* From https://launchpad.net/cloud-init , under `Series and milestones` (middle of page), click the `trunk` series. If you see no `trunk` series, then click `View full history` and find it there
+* Under the `Milestones and releases` section, click the `Create milestone` button
+* Set Name to `<next scheduled release>`. For example, if current release is '21.3', Name should be '21.4'
+* If we have a scheduled date for the next release, set the date, otherwise leave it blank
+* Leave everything else blank, and click `Create Milestone`
 
-    $ lp-project-upload cloud-init 17.2 cloud-init-17.2.tar.gz 17.3 changelog-file releasenotes-file
-
+## Create release in github
+* Visit https://github.com/canonical/cloud-init/releases
+* Click 'Draft new release'
+* In the 'Choose a tag' dropdown, select tag pushed earlier
+* Set `<version>` as Release title
+* Set `'Release <version>'` as the description
+* Click 'Publish release'
 
 ## Close bugs.
-Any bugs that were listed should be marked as 'fix-released' now.
+Any Launchdpad bugs that were listed in the git commit messages from this release should be marked as 'fix-released' now.
+
 There is a tool in
-[uss-tableflip](https://github.com/CanonicalLtd/uss-tableflip) called
-lp-bugs-released that makes this sane.
+[uss-tableflip](https://github.com/canonical/uss-tableflip/) called
+lp-bugs-released that makes this sane:
+```bash
+$ ./lp-bugs-released <project> <version> <space separate list of bugs>
+```
+Example:
+```bash
+$ ./lp-bugs-release cloud-init 21.3 1867532 1911680 1925395 1931392 1931577 1932048 1940233 1940235 1940839
+```
 
-    # git log <last-release>..<this-release>
-    $ git log 17.1..17.2 | grep "^[ ]*LP:" | sort -u
-    $ ./lp-bugs-released <project> <version> <bug list here>
+To get the list of bug that have been fixed this release, use:
+```bash
+$ git log <previous_version>..<version> | grep "^[ ]*LP:" | sort -u | awk -F 'LP: #' '{printf $2 " "}'
+```
 
-Basically copy the Release Notes and the Changelog into an email to
-Cloud-init Mailing List <cloud-init@lists.launchpad.net>
-
-Example Emails from the past at
-
- * [17.1](https://lists.launchpad.net/cloud-init/msg00106.html)
-
-Please sign the email.
-
-
-## Upload to Ubuntu devel release.
-Follow the Ubuntu release process doc [ubuntu-release-process](https://gist.github.com/smoser/6391b854e6a80475aac473bba4ef0310#file-ubuntu-release-process-md)
+## Upload to ubuntu/devel
+See the SRU documentation
 
 ## Update COPR build cloud-init/el-testing repository with latest upstream release
- * Build srpm
+ Build RPM with:
+```bash
+$ ./tools/run-container --source-package --unittest --artifacts=./srpm/ rockylinux/8
+```
+* Load [el-testing project/builds](https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-testing/builds/)
+* Click New Build button -> Upload tab -> upload your src.rpm file
+* Unselect all 'Chroots' except for 'epel-8-x86_64'
+* Click 'Build'
 
-       $ ./tools/run-container --source-package --unittest --artifacts=./srpm/ centos/7
+# Post-release
+## Send release email and post to Discourse
+Example emails:
+* https://lists.launchpad.net/cloud-init/msg00362.html
+* https://lists.launchpad.net/cloud-init/msg00338.html
 
- * Load [el-testing project/builds](https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-testing/builds/)
- * Click New Build button -> Upload tab -> upload your src.rpm file
-
-
-# Opening next release
-
-  * Go to https://launchpad.net/cloud-init/trunk . Create a milestone,
-    enter the next release number (YY.1) and pick a target date.
+Example discourse:
+* https://discourse.ubuntu.com/t/release-of-cloud-init-21-3/23857

--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -141,7 +141,7 @@ $ git log <previous_version>..<version> | grep "^[ ]*LP:" | sort -u | awk -F 'LP
 ```
 
 ## Upload to ubuntu/devel
-See the SRU documentation
+TODO: link to SRU documentation
 
 ## Update COPR build cloud-init/el-testing repository with latest upstream release
  Build RPM with:

--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -128,14 +128,14 @@ There is a tool in
 [uss-tableflip](https://github.com/canonical/uss-tableflip/) called
 lp-bugs-released that makes this sane:
 ```bash
-$ ./lp-bugs-released <project> <version> <space separate list of bugs>
+$ ./lp-bugs-released <project> <version> <space separated list of bugs>
 ```
 Example:
 ```bash
 $ ./lp-bugs-release cloud-init 21.3 1867532 1911680 1925395 1931392 1931577 1932048 1940233 1940235 1940839
 ```
 
-To get the list of bug that have been fixed this release, use:
+To get the list of bugs that have been fixed this release, use:
 ```bash
 $ git log <previous_version>..<version> | grep "^[ ]*LP:" | sort -u | awk -F 'LP: #' '{printf $2 " "}'
 ```

--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -124,24 +124,23 @@ Once we have created our release, we should create the milestone for the next re
 * Set `'Release <version>'` as the description
 * Click 'Publish release'
 
-## Close bugs.
+## Close bugs
 Any Launchdpad bugs that were listed in the git commit messages from this release should be marked as 'fix-released' now.
 
-There is a tool in
-[uss-tableflip](https://github.com/canonical/uss-tableflip/) called
-lp-bugs-released that makes this sane:
+First, get the list of bugs that been fixed this release:
+```bash
+$ git log <previous_version>..<version> | grep "^[ ]*LP:" | sort -u | awk -F 'LP: #' '{printf $2 " "}'
+```
+
+Next, use the uss-tableflip script called lp-bugs-released to close the bugs:
 ```bash
 $ ./lp-bugs-released <project> <version> <space separated list of bugs>
 ```
 Example:
 ```bash
-$ ./lp-bugs-release cloud-init 21.3 1867532 1911680 1925395 1931392 1931577 1932048 1940233 1940235 1940839
+$ ./lp-bugs-released cloud-init 21.3 1867532 1911680 1925395 1931392 1931577 1932048 1940233 1940235 1940839
 ```
 
-To get the list of bugs that have been fixed this release, use:
-```bash
-$ git log <previous_version>..<version> | grep "^[ ]*LP:" | sort -u | awk -F 'LP: #' '{printf $2 " "}'
-```
 
 ## Upload to ubuntu/devel
 TODO: link to SRU documentation


### PR DESCRIPTION
A (mostly) rewrite of the upstream release process. Includes every step we had on our trello board and generally includes more details. Selecting `view file` will show the rendered markdown, and might be better than looking at the diff view.