### PR TITLE
new-upstream-snapshot: add --first-devel-upload param

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -38,7 +38,10 @@ options:
       --first-sru                 provide this flag when this is the first SRU
                                   to a series. It will determine the right
                                   version suffix, prompt for SRU bug.
-   -v|--verbose                  increase verbosity.
+      --first-devel-upload        provide this flag when this is the first
+                                  upload to a devel series. It will determine
+                                  the right version suffix, prompt for SRU bug.
+   -v|--verbose                   increase verbosity.
 EOF
 }
 
@@ -166,14 +169,14 @@ is_merge_commit() {
 
 main() {
     local short_opts="hv"
-    local long_opts="help,update-patches-only,no-bugs,first-sru,skip-branch-name-check,skip-release,sru-bug:,verbose"
+    local long_opts="help,update-patches-only,no-bugs,first-devel-upload,first-sru,skip-branch-name-check,skip-release,sru-bug:,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
         eval set -- "${getopt_out}" ||
         { Usage; return; }
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
-    local update_patches_only=false first_sru=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
+    local update_patches_only=false first_devel_upload=false first_sru=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
     local cur="" next="" 
     while [ $# -ne 0 ]; do
@@ -185,6 +188,7 @@ main() {
                --update-patches-only) update_patches_only=true;;
                --sru-bug) sru_bug_fillstr=$next; shift;;
                --no-bugs) bug_refs_in_clog=false;;
+               --first-devel-upload) bug_refs_in_clog=true; first_devel_upload=true;;
                --first-sru) bug_refs_in_clog=false; first_sru=true;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             --) shift; break;;
@@ -253,6 +257,10 @@ main() {
         command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
         # get ~20.10.1 for latest --stable release
         sru_ver_suff=$(distro-info --stable -r | awk '{printf "~%s.1", $1}')
+    elif [ "$first_devel_upload" = "true" ]; then
+        command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
+        # get ~22.04.1 for latest --devel release
+        sru_ver_suff=$(distro-info --devel -r | awk '{printf "~%s.1", $1}')
     else
         # if present, pull the '~16.04.x' off of the previous entry.
         sru_ver_suff=$(echo "$prev_pkg_ver" |
@@ -262,7 +270,7 @@ main() {
 
     local sru_bug_string="" skip_bugs=""
     [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"
-    if [ -n "$sru_ver_suff" ]; then
+    if [ -n "${sru_ver_suff}" ] && [ "${first_devel_upload}" = "false" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
         skip_bugs="--skip-bugs"
     fi
@@ -296,8 +304,12 @@ main() {
             dpkg-parsechangelog --offset 1 --count=1 --show-field Version)
         unreleased_changes=$(
             dpkg-parsechangelog --count=1 --show-field Changes | tail -n +4)
-        prev_dist=$(
-            dpkg-parsechangelog --offset 1 --count=1 --show-field Distribution)
+        if [ "${first_devel_upload}" = "true" ]; then
+            prev_dist=$(distro-info --devel)
+        else
+            prev_dist=$(
+                dpkg-parsechangelog --offset 1 --count=1 --show-field Distribution)
+        fi
     else
         prev_released_pkg_ver="${prev_pkg_ver}"
         prev_dist="$dist"


### PR DESCRIPTION
Ensure we grab the devel release information for our first uploads
into a new Ubuntu release.

When uploading to the new devel release use distro-info --devel to
get both series name and version_id which we now use for package
suffix.

Upload into devel release should always contain LP bug ids until that
release is officially published and "stable".