### PR TITLE
new-upstream-snapshot: fix devel detection because we add ver suffix

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -210,7 +210,7 @@ main() {
 
     local cur_branch="" prev_pkg_ver pkg_name dist prev_dist t=""
     local prev_pkg_hash="" new_pkg_debian="" new_upstream_ver="" new_pkg_ver=""
-    local sru_ver_suff="" upstream_hash=""
+    local ver_suff="" upstream_hash=""
     local from_ref="$1"
 
     if [ -z "$from_ref" ]; then
@@ -253,24 +253,25 @@ main() {
     dist=$(dpkg-parsechangelog --show-field Distribution)
 
 
+    command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
+    devel_ver=$(distro-info --devel -r | awk '{printf $1}')
     if [ "$first_sru" = "true" ]; then
-        command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
         # get ~20.10.1 for latest --stable release
-        sru_ver_suff=$(distro-info --stable -r | awk '{printf "~%s.1", $1}')
+        ver_suff=$(distro-info --stable -r | awk '{printf "~%s.1", $1}')
     elif [ "$first_devel_upload" = "true" ]; then
-        command -v distro-info >/dev/null 2>&1 || fail "Install distro-info deb"
         # get ~22.04.1 for latest --devel release
-        sru_ver_suff=$(distro-info --devel -r | awk '{printf "~%s.1", $1}')
+        ver_suff="~${devel_ver}.1"
     else
         # if present, pull the '~16.04.x' off of the previous entry.
-        sru_ver_suff=$(echo "$prev_pkg_ver" |
+        ver_suff=$(echo "$prev_pkg_ver" |
             sed 's,.*~\([0-9.]*\)[.][0-9]$,~\1.1,')
-        [ "${sru_ver_suff}" = "${prev_pkg_ver}" ] && sru_ver_suff=""
+        [ "${ver_suff}" = "${prev_pkg_ver}" ] && ver_suff=""
     fi
+    is_devel=$(test "${ver_suff#*$devel_ver}" != "${ver_suff}" && echo "true" || echo "false")
 
     local sru_bug_string="" skip_bugs=""
     [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"
-    if [ -n "${sru_ver_suff}" ] && [ "${first_devel_upload}" = "false" ]; then
+    if [ "${is_devel}" = "false" ] && [ "${first_devel_upload}" = "false" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
         skip_bugs="--skip-bugs"
     fi
@@ -282,7 +283,7 @@ main() {
     new_pkg_debian="0ubuntu1"
     new_upstream_ver=$(git describe --abbrev=8 "${from_ref}")
     upstream_hash=$(git rev-parse --short=8 "${from_ref}")
-    new_pkg_ver="${new_upstream_ver}-${new_pkg_debian}${sru_ver_suff}"
+    new_pkg_ver="${new_upstream_ver}-${new_pkg_debian}${ver_suff}"
 
     case "$new_upstream_ver" in
         *-[0-9]*-g[a-f0-9]*) new_msg="New upstream snapshot.";;
@@ -497,7 +498,7 @@ main() {
     local tag=""
     tag=$(echo "ubuntu/$new_pkg_ver" | tr '~' '_')
     release_suffix=""
-    if [ -n "${sru_ver_suff}" ] &&
+    if [ "${is_devel}" = "true" ] &&
         [ "${NUS_PROPOSED_IN_CHANGELOG:-0}" != "0" ]; then
         # we do not add '-proposed' to the changelog file as
         # doing so means that an upload of that to a PPA will be rejected.


### PR DESCRIPTION
# suggested commit message
```
new-upstream-snapshot: fix devel detection because we add ver suffix

cloud-init now appends a package version suffix even on devel
releases. Fux new-upstream-snapshot to detect if our suffix matches the
current devel release.
```

# desired commit type
squash and merge