### PR TITLE
log2dch: do not consider ignore SC-<JIRA> fixes

### DIFF
--- a/scripts/log2dch
+++ b/scripts/log2dch
@@ -162,7 +162,7 @@ print_dch() {
     local i=""
     aname=${author% <*}
     case "$aname" in
-        Chad\ Smith|Daniel\ Watkins|Lucas\ Moura|James\ Falcon|Brett\ Holman) aname="";;
+        Chad\ Smith|Lucas\ Moura|James\ Falcon|Brett\ Holman) aname="";;
     esac
     abugs="${aname:+ [${aname}]}${bugs:+ (${bug_tracker}: ${bugs})}"
     for filter in "${FILTER_LIST[@]}"; do
@@ -213,8 +213,11 @@ git_log_to_dch() {
                 subject=""
                 ;;
             Author:*) author="${line#Author: }";;
-            LP:*) bugs="${bugs:+${bugs}, }${line#*: }";;
-            Fixes:*|Closes:*) bug_tracker="GH"; bugs="${bugs:+${bugs}, }${line#*: }";;
+            LP:*) bug_tracker="LP"; bugs="${bugs:+${bugs}, }${line#*: }";;
+            Fixes:*|Closes:*)
+                bug_tracker="GH";
+                bug="${line#*: }";
+                [ ! -z "${bug##*[!0-9]*}" ] && bugs="${bugs:+${bugs}, }$bug";;
             "") [ -z "$subject" ] && read -r subject;;
         esac
     done


### PR DESCRIPTION
ignore non integer `Fixes: SC-##` in commit messages.
Expect github issues to be reprented by a commit message containing
the footer of the formats:
  Issue: <GITHUB_ISSUE_NUMBER>
   - OR -
  Fixes: <GITHUB_ISSUE_NUMBER>

The avoids log2dch reporting (GH: SC-123) for JIRA ticket tracking we do.

Also, allow assume each commit can reference either github issues (GH: #)
or launchpad bug tracker (LP: #) but not both.
This will likely need improved logic in the future.

# test steps
* Before PR
```bash
cd your-cloud-init-path;
git checkout upstream/main
git log 22.1..HEAD | log2dch | grep GH > BEFORE
cd your-uss-tableflip-path;
git checkout <this_PR>;
cd your-cloud-init-path;
# SC-* and GH references should not be represented as we don't yet fix github issues.
git log 22.1..HEAD | log2dch | grep GH >AFTER
```