### PR TITLE
new-upstream-snapshot: move toward using gbp-dch

### DIFF
--- a/doc/upstream_release_process.md
+++ b/doc/upstream_release_process.md
@@ -14,12 +14,17 @@ Adjust any references to `upstream` and `origin` accordingly if yours are differ
 
 ## Tools on path
 Some scripts referenced in this guide invoke other tools assumed to be on the PATH, so add `uss-tableflip/scripts` to your PATH.
-Additionally, the `lptools` package should be installed. Use `apt` to install it.
+Additionally, the `lptools` package and `git-buildpackage` should be installed. Use `apt` to install them.
 
 ## Tools Updated For Core Contributors
 To avoid repetitive names in the cloud-init changelog, core contributors' names are excluded from the changelog contribution list.
-New core contributors should add themselves to the list in
-[log2dch](https://github.com/canonical/uss-tableflip/blob/main/scripts/log2dch)
+
+New core contributors should add themselves to the list in the following locations:
+* [log2dch](https://github.com/canonical/uss-tableflip/blob/main/scripts/log2dch)
+* [gbp_format_changelog](https://github.com/canonical/uss-tableflip/blob/main/scripts/gbp_format_changelog)
+
+**NOTE:** `new-upstream-snapshot` uses git-buildpackage to generate debian/changelog entries. For project customization, copy `scripts/add_changelog.py`, `scripts/gbp_format_changelog` and `scripts/gbp.conf` into your project's **debian/** directory.
+
 
 # Pre-release
 ## Send pre-release email to mailing list

--- a/scripts/add_changelog.py
+++ b/scripts/add_changelog.py
@@ -1,0 +1,133 @@
+"""add_changelog: add unreleased commits to debian/changelog
+
+Use gbp-dch and dch tooling to inject time-ordered changelog comments
+for each commit into the package's debian/changelog.
+
+This script is typically invoked from new-upstream-snapshot when pulling
+down all upstream commits into a packaging branch.
+
+See:
+https://github.com/canonical/uss-tableflip/blob/main/doc/ubuntu_release_process.md
+"""
+
+import argparse
+import os
+import re
+import sys
+from subprocess import check_output
+
+
+NEW_UPSTREAM_MSG = "New upstream"
+PKG_RELEASE_RE = (
+    "(?P<pkg_name>[^ ]+) \((?P<version>[^)]+)\) (?P<dist>[^;]+);"
+    " urgency=(?P<urgency>\w+).*"
+)
+CHANGELOG_FILE = "debian/changelog"
+GIT_GBP_CONF = ".git/gbp.conf"
+PACKAGE_GBP_CONF = "debian/gbp.conf"
+PACKAGE_GBP_CUSTOMIZATION = "debian/gbp_format_changelog"
+
+DEFAULT_GBP_CONF = os.path.join(os.path.dirname(__file__), "gbp.conf")
+DEFAULT_GBP_CUSTOMIZATION = os.path.join(
+    os.path.dirname(__file__), "gbp_format_changelog"
+)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("message", help="Changelog message to add")
+    parser.add_argument("version", help="Packaging version for changelog")
+    parser.add_argument(
+        "include_bugs",
+        help='Set "true" to include bugs in changelog',
+        choices=["true", "false"],
+    )
+    return parser
+
+
+def _get_gbp_env():
+    """Return a dict of gbp-related environment variables."""
+    if not any(
+        [
+            os.path.exists(PACKAGE_GBP_CONF),
+            os.path.exists(GIT_GBP_CONF),
+        ]
+    ):
+        print(
+            f"NOTICE: no gbp.conf found in debian/ or .git/."
+            f" Using: {DEFAULT_GBP_CONF}"
+        )
+        return {"GBP_CONF_FILES": DEFAULT_GBP_CONF}
+    return None
+
+
+def add_changelog(msg: str, version: str, include_bugs: str = "false"):
+    with open(CHANGELOG_FILE) as stream:
+        full_changelog = stream.read().splitlines()
+    unreleased_snapshot_messages = []  # Upstream snapshot commit messages
+    changelog_lines = []
+    pkg_info = re.match(PKG_RELEASE_RE, full_changelog[0]).groupdict()
+    unreleased_commitish = None
+    if pkg_info["dist"] == "UNRELEASED":
+        # Reconstruct top changelog entry
+        _, _, pkg_commitish = pkg_info["version"].partition("g")
+        if len(pkg_commitish) == 8:  # Then we have the commitish
+            orig_commitish = pkg_commitish
+        found_snapshot = False
+        changelog_count = 0
+        for line in full_changelog:
+            if re.match(
+                rf"{pkg_info['pkg_name']} .*urgency={pkg_info['urgency']}", line
+            ):
+                changelog_count += 1
+            if NEW_UPSTREAM_MSG in line and changelog_count == 1:
+                found_snapshot = True
+                continue
+            if found_snapshot and changelog_count == 1:
+                if line and not line.startswith(" -- "):
+                    if NEW_UPSTREAM_MSG not in line:
+                        unreleased_snapshot_messages.append(
+                            re.sub(r"^ +\+ ?", "+", line)
+                        )
+                else:
+                    changelog_lines.append(line)
+            else:
+                changelog_lines.append(line)
+        if changelog_lines != full_changelog:
+            with open(CHANGELOG_FILE, "w") as stream:
+                stream.write("\n".join(changelog_lines) + "\n")
+    # Add current msg comment
+    gbp_cmd = ["gbp", "dch", "--ignore-branch", f"--new-version={version}"]
+    for msg_line in msg.splitlines():
+        check_output(["dch", "-b", "-v", version, msg_line])
+    if pkg_info["dist"] == "UNRELEASED":
+        if not unreleased_commitish:
+            _, _, pkg_commitish = pkg_info["version"].partition("g")
+            if len(pkg_commitish) == 8:
+                unreleased_commitish = pkg_commitish
+    if not os.path.exists(PACKAGE_GBP_CUSTOMIZATION):
+        print(
+            f"NOTICE: no {PACKAGE_GBP_CUSTOMIZATION} found. "
+            f"Using: {DEFAULT_GBP_CUSTOMIZATION}"
+        )
+        gbp_cmd += ["--customizations", DEFAULT_GBP_CUSTOMIZATION]
+    if unreleased_commitish:
+        gbp_cmd += ["-s", unreleased_commitish]
+    if include_bugs == "false":
+        # Skip any bug matches due in changelog entries
+        gbp_cmd += ["--meta-closes-bugnum='MATCHNOBUGS'"]
+    if NEW_UPSTREAM_MSG in msg:
+        print(f"CHAD {include_bugs} {gbp_cmd}")
+        check_output(gbp_cmd, env=_get_gbp_env())
+    for msg in unreleased_snapshot_messages:
+        check_output(["dch", "-v", version, msg])
+    check_output(["sed", "-i", "s/ \* +/   + /", CHANGELOG_FILE])
+    check_output(["sed", "-i", "s/\*       /    /", CHANGELOG_FILE])
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    add_changelog(
+        msg=args.message, version=args.version, include_bugs=args.include_bugs
+    )

--- a/scripts/gbp.conf
+++ b/scripts/gbp.conf
@@ -1,0 +1,12 @@
+# Configuration file for "gbp <command>"
+
+# See default config settings at: /etc/git-buildpackage/gbp.conf
+
+# Options only affecting gbp dch
+[dch]
+# options passed to git-log:
+git-log = --no-merges --reverse
+# Customizatons can e.g. be used for line wrapping
+customizations=./debian/gbp_format_changelog
+multimaint-merge = False
+multimaint = False

--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -18,6 +18,10 @@ import gbp.dch
 # To override this default filter behavior, copy this file into your project's
 # ./debian/ directory and adapt as needed.
 
+
+# To filter Jira tickets from "SC" project out of potential changelog comments
+JIRA_PROJECT_KEY = "SC"
+
 FILTER_UPSTREAM_COMMITERS = (  # cloud-init upstream author names
     "Chad Smith",
     "James Falcon",
@@ -67,7 +71,7 @@ def _wrap_on_delimiter(text, prefix="", max_length=70) -> list:
 
 def format_changelog_entry(commit_info, options, last_commit=False):
     entry = gbp.dch.format_changelog_entry(commit_info, options, last_commit)
-    if re.search(r"\(SC-\d+\)", entry[0]):
+    if re.search(rf"\({JIRA_PROJECT_KEY}-\d+\)", entry[0]):
         # Remove JIRA card references from debian/changelog comments
         entry[0] = re.sub(r"\(SC-\d+\)", "", entry[0])
     if commit_info["author"].name not in FILTER_UPSTREAM_COMMITERS:

--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -11,7 +11,14 @@ import textwrap
 
 import gbp.dch
 
-FILTER_CLOUD_INIT_UPSTREAM_COMMITERS = (
+# FILTER_UPSTREAM_COMMMITERS are authors for which to redact [author name]
+# suffix per changelog message. The reason we redact those names as they
+# will be repeated for most changelog entries.
+
+# To override this default filter behavior, copy this file into your project's
+# ./debian/ directory and adapt as needed.
+
+FILTER_UPSTREAM_COMMITERS = (  # cloud-init upstream author names
     "Chad Smith",
     "James Falcon",
     "Brett Holman",
@@ -63,7 +70,7 @@ def format_changelog_entry(commit_info, options, last_commit=False):
     if re.search(r"\(SC-\d+\)", entry[0]):
         # Remove JIRA card references from debian/changelog comments
         entry[0] = re.sub(r"\(SC-\d+\)", "", entry[0])
-    if commit_info["author"].name not in FILTER_CLOUD_INIT_UPSTREAM_COMMITERS:
+    if commit_info["author"].name not in FILTER_UPSTREAM_COMMITERS:
         # Only append non-upstream authors since most committers are upstream
         entry.append(f"[{commit_info['author'].name}]")
     if entry:

--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -18,10 +18,6 @@ import gbp.dch
 # To override this default filter behavior, copy this file into your project's
 # ./debian/ directory and adapt as needed.
 
-
-# To filter Jira tickets from "SC" project out of potential changelog comments
-JIRA_PROJECT_KEY = "SC"
-
 FILTER_UPSTREAM_COMMITERS = (  # cloud-init upstream author names
     "Chad Smith",
     "James Falcon",
@@ -32,6 +28,9 @@ FILTER_NOISY_COMMIT_REGEX = (
     r"update changelog.*",
     r"refresh patches against.*",
 )
+
+# To filter Jira tickets from "SC" project out of potential changelog comments
+JIRA_PROJECT_KEY = "SC"
 
 UNWRAPPABLE_DELIMITERS = {
     "]": "[",
@@ -73,7 +72,7 @@ def format_changelog_entry(commit_info, options, last_commit=False):
     entry = gbp.dch.format_changelog_entry(commit_info, options, last_commit)
     if re.search(rf"\({JIRA_PROJECT_KEY}-\d+\)", entry[0]):
         # Remove JIRA card references from debian/changelog comments
-        entry[0] = re.sub(r"\(SC-\d+\)", "", entry[0])
+        entry[0] = re.sub(r"\({JIRA_PROJECT_KEY}-\d+\)", "", entry[0])
     if commit_info["author"].name not in FILTER_UPSTREAM_COMMITERS:
         # Only append non-upstream authors since most committers are upstream
         entry.append(f"[{commit_info['author'].name}]")

--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Simple changelog entry formatter
+#
+# It simply uses the built in formatter and linewraps the text
+#
+# Use git-dch --customizations=/usr/share/doc/git-buildpackage/examples/wrap_cl.py
+# or set it via gbp.conf
+
+import textwrap
+import re
+import gbp.dch
+
+
+FILTER_CLOUD_INIT_UPSTREAM_COMMITERS = (
+    "Chad Smith", "James Falcon", "Brett Holman"
+)
+
+FILTER_NOISY_COMMIT_REGEX = (
+  r'update changelog.*',
+  r'refresh patches against.*',
+)
+
+UNWRAPPABLE_DELIMITERS = {
+  "]": "[",
+  ")": "(",
+}
+
+
+def _wrap_on_delimiter(text, prefix="", max_length=70) -> list:
+    """Break lines at specific UNWRAPPABLE_DELIMITERS.
+
+    When a line ends with either (LP: #XXX) or [Author Name] avoid using
+    textwrap.wrap which breaks at the last whitespace.
+
+    Instead break at the leading ( or [ special delimiter to ensure entire
+    author name or LP bug reference remains on the same line.
+
+    Fallback to use textwrap.wrap if special conditions don't apply.
+
+    Return a list of individual lines.
+    """
+    if len(text) <= max_length:
+        return [prefix + text]
+    if text[-1] in UNWRAPPABLE_DELIMITERS:
+        delimiter = UNWRAPPABLE_DELIMITERS[text[-1]]
+        part1, sep, part2 = text.rpartition(delimiter)
+        remainder = ""
+        lines = []
+        for part in (part1.rstrip(), f"{sep}{part2}"):
+            if lines:
+                if len(lines[-1] + " " + part) < 70:
+                    # Then the previous part plus current part should be joined
+                    part = lines.pop() + " " + part
+                part = f" {part}"
+            lines.extend(
+                _wrap_on_delimiter(part, prefix = "" if lines else "+")
+            )
+        return lines
+    return textwrap.wrap(prefix + text)
+
+
+def format_changelog_entry(commit_info, options, last_commit=False):
+    entry = gbp.dch.format_changelog_entry(commit_info, options, last_commit)
+    if re.search(r"\(SC-\d+\)", entry[0]):
+        # Remove JIRA card references from debian/changelog comments
+        entry[0] = re.sub(r"\(SC-\d+\)", "", entry[0])
+    if commit_info['author'].name not in FILTER_CLOUD_INIT_UPSTREAM_COMMITERS:
+        # Only append non-upstream authors since most committers are upstream
+        entry.append(f"[{commit_info['author'].name}]")
+    if entry:
+        combined_entry = " ".join(entry)
+        for filter_re in FILTER_NOISY_COMMIT_REGEX:
+            if re.match(filter_re, combined_entry):
+                return None
+        return _wrap_on_delimiter(combined_entry, prefix = "+")

--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -3,26 +3,28 @@
 #
 # It simply uses the built in formatter and linewraps the text
 #
-# Use git-dch --customizations=/usr/share/doc/git-buildpackage/examples/wrap_cl.py
+# Use git-dch --customizations=/<uss_tableflip>/scripts/gbp_format_changelog
 # or set it via gbp.conf
 
-import textwrap
 import re
+import textwrap
+
 import gbp.dch
 
-
 FILTER_CLOUD_INIT_UPSTREAM_COMMITERS = (
-    "Chad Smith", "James Falcon", "Brett Holman"
+    "Chad Smith",
+    "James Falcon",
+    "Brett Holman",
 )
 
 FILTER_NOISY_COMMIT_REGEX = (
-  r'update changelog.*',
-  r'refresh patches against.*',
+    r"update changelog.*",
+    r"refresh patches against.*",
 )
 
 UNWRAPPABLE_DELIMITERS = {
-  "]": "[",
-  ")": "(",
+    "]": "[",
+    ")": "(",
 }
 
 
@@ -44,7 +46,6 @@ def _wrap_on_delimiter(text, prefix="", max_length=70) -> list:
     if text[-1] in UNWRAPPABLE_DELIMITERS:
         delimiter = UNWRAPPABLE_DELIMITERS[text[-1]]
         part1, sep, part2 = text.rpartition(delimiter)
-        remainder = ""
         lines = []
         for part in (part1.rstrip(), f"{sep}{part2}"):
             if lines:
@@ -52,9 +53,7 @@ def _wrap_on_delimiter(text, prefix="", max_length=70) -> list:
                     # Then the previous part plus current part should be joined
                     part = lines.pop() + " " + part
                 part = f" {part}"
-            lines.extend(
-                _wrap_on_delimiter(part, prefix = "" if lines else "+")
-            )
+            lines.extend(_wrap_on_delimiter(part, prefix="" if lines else "+"))
         return lines
     return textwrap.wrap(prefix + text)
 
@@ -64,7 +63,7 @@ def format_changelog_entry(commit_info, options, last_commit=False):
     if re.search(r"\(SC-\d+\)", entry[0]):
         # Remove JIRA card references from debian/changelog comments
         entry[0] = re.sub(r"\(SC-\d+\)", "", entry[0])
-    if commit_info['author'].name not in FILTER_CLOUD_INIT_UPSTREAM_COMMITERS:
+    if commit_info["author"].name not in FILTER_CLOUD_INIT_UPSTREAM_COMMITERS:
         # Only append non-upstream authors since most committers are upstream
         entry.append(f"[{commit_info['author'].name}]")
     if entry:
@@ -72,4 +71,4 @@ def format_changelog_entry(commit_info, options, last_commit=False):
         for filter_re in FILTER_NOISY_COMMIT_REGEX:
             if re.match(filter_re, combined_entry):
                 return None
-        return _wrap_on_delimiter(combined_entry, prefix = "+")
+        return _wrap_on_delimiter(combined_entry, prefix="+")

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -138,7 +138,7 @@ main() {
                --no-bugs) bug_refs_in_clog=false;;
                --first-devel-upload) bug_refs_in_clog=true; first_devel_upload=true;;
                --first-sru) bug_refs_in_clog=false; first_sru=true;;
-            -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
+            -v|--verbose) VERBOSITY=$((VERBOSITY+1));;
             --) shift; break;;
         esac
         shift;
@@ -150,7 +150,7 @@ main() {
         return;
     }
 
-    if [ -z "$DEBFULLNAME" -o -z "$DEBEMAIL" ]; then
+    if [ -z "$DEBFULLNAME" ] || [ -z "$DEBEMAIL" ]; then
         error "Must set DEBFULLNAME and DEBEMAIL per"
         error "  https://www.debian.org/doc/manuals/maint-guide/first.en.html"
         fail
@@ -220,12 +220,7 @@ main() {
     local sru_bug_string=""
     if [ "${is_devel}" = "false" ] && [ "${first_devel_upload}" = "false" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
-        skip_bugs="true"
     fi
-
-    # turn 0.7.7-10-gbc2c326-0ubuntu1 into 'bc2c326'
-    t=${prev_pkg_ver%-*}
-    prev_pkg_hash=${t##*-g}
 
     new_pkg_debian="0ubuntu1"
     new_upstream_ver=$(git describe --abbrev=8 "${from_ref}")
@@ -300,13 +295,13 @@ main() {
                 git rm "$file" || fail "failed to git rm $file"
                 msg="${msg}$CR  ${file##*/}"
             done
-            git commit -m "$msg" "$dpseries" $drops
+            git commit -m "$msg" "$dpseries" "$drops"
 
             msg="drop the following cherry-picks now included:"
             for file in $drops; do
                 msg="${msg}$CR+${file##*/}"
             done
-            python3 $(dirname $0)/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
+            python3 "$(dirname "$0")"/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
                 fail "failed adding changelog entry cherry-pick drops."
             git commit -m "update changelog." debian/changelog ||
                 fail "failed to commit changelog changes for drops."
@@ -369,12 +364,12 @@ main() {
                 echo "refresh patches against ${from_ref} commit" \
                      "${upstream_hash}:"
                 for i in ${refreshed}; do echo "+$i"; done)
-            git commit -m "$msg" $refreshed ||
+            git commit -m "$msg" "$refreshed" ||
                 fail "failed to commit refreshed patches: $refreshed"
             msg=$(
                 echo "refresh patches:"
                 for i in ${refreshed}; do echo "+$i"; done)
-            python3 $(dirname $0)/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
+            python3 "$(dirname "$0")"/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
                 fail "failed adding changelog entry for refresh"
             git commit -m "update changelog." debian/changelog ||
                 fail "failed to commit changelog changes."
@@ -382,7 +377,7 @@ main() {
     fi
 
     if [ "$update_patches_only" = "true" ]; then
-        if [ -z "$drops" -a -z "$refreshed" ]; then
+        if [ -z "$drops" ] && [ -z "$refreshed" ]; then
             error "No patches updated. Nothing to commit. restoring to $ORIG_TIP"
             git reset --hard "$ORIG_TIP" ||
                 fail "failed to reset back to start commit $ORIG_TIP"
@@ -405,16 +400,15 @@ main() {
         return 0
     fi
 
-    local clog="${TEMP_D}/changelog" gitlog="${TEMP_D}/gitlog"
     header="$new_msg${sru_bug_string:+ ${sru_bug_string}}"
-    python3 $(dirname $0)/add_changelog.py "${header}" "${new_pkg_ver}" "${bug_refs_in_clog}" || fail
+    python3 "$(dirname "$0")"/add_changelog.py "${header}" "${new_pkg_ver}" "${bug_refs_in_clog}" || fail
 
     dch -e || fail "dch -e exited $?"
 
     if [ "${skip_release}" = "false" ]; then
         if grep -q "SRU_BUG_NUMBER_HERE" debian/changelog; then
             echo "You did not fill in an SRU bug string.  Add one now."
-            read answer
+            read -r answer
             dch -e
             grep -q "$sru_bug_fillstr" debian/changelog &&
                 fail "You didn't fix it (debian/changelog has $sru_bug_string)"
@@ -424,7 +418,7 @@ main() {
     git diff
 
     echo -n "Commit this change? (Y/n): "
-    read answer || fail "failed to read answer"
+    read -r answer || fail "failed to read answer"
     case "$answer" in
         n|[Nn][oO]) fail;;
     esac
@@ -445,7 +439,7 @@ main() {
     else
         prev_dist=${prev_dist%-proposed}
     fi
-    echo wrote new-upstream-changes.txt for $pkg_name version ${new_pkg_ver}.
+    echo wrote new-upstream-changes.txt for "${pkg_name}" version "${new_pkg_ver}".
     if [ "${skip_release}" = "true" ]; then
         cat <<EOF
         push your branch for review:

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -64,59 +64,6 @@ cleanup() {
 }
 
 
-add_changelog_entries() {
-    # if top commit has UNRELEASED, then add these to that.
-    # otherwise, add a new entry.  Basically similar behavior
-    # to what 'dch -i' gives you.
-    # the entries need to be indented properly (  * your-entry)
-    local entries="$1" version="$2" dist="" unrel_entries="" tmp="" out=""
-    local changelog="debian/changelog" old="${TEMP_D}/old-changes"
-    local pkg_name="" new="${TEMP_D}/unreleased-changes"
-    local snapshot_header="New upstream snapshot"
-    dist=$(dpkg-parsechangelog --show-field Distribution)
-    pkg_name=$(dpkg-parsechangelog --show-field Source)
-    if [ "$dist" = "UNRELEASED" ]; then
-        unrel_entries=$(
-            dpkg-parsechangelog --count=1 --show-field Changes | tail -n +4)
-        if [ -z "$version" ]; then
-            version=$(
-                dpkg-parsechangelog --count=1 --show-field Version)
-        fi
-        local pver=""
-        pver=$(dpkg-parsechangelog --offset 1 --count=1 --show-field Version)
-        sed -n "/ (${pver})/,\$p" "debian/changelog" > "$old"
-    else
-        if [ -z "$version" ]; then
-            local lastnum=""
-            out=$(dpkg-parsechangelog --count=1 --show-field Version)
-            tmp=${out%?}
-            lastnum=${out#${tmp}}
-            version=${tmp}$((lastnum+1))
-        fi
-        cp "$changelog" "$old"
-    fi
-    {
-    echo "$pkg_name ($version) UNRELEASED; urgency=medium"
-    echo
-    if [ -n "${unrel_entries}" ]; then
-        # If both unreleased and new entries are New upstream snapshots
-        # combine them
-        { IFS="$CR"; set -- $unrel_entries; IFS="$oifs"; }
-        for line in "$@"; do
-            case "${line}" in
-                # Inject current entries in place of previous snapshot_header
-                *${snapshot_header}*) echo "${entries}"; entries="";;
-                # Print rest of unreleased lines in the changelog
-                *) echo "${line}";;
-            esac
-        done
-    fi
-    [ -n "${entries}" ] && echo "${entries}"
-    printf "\n -- %s <%s>  %s\n\n" "$DEBFULLNAME" "$DEBEMAIL" "$(date -R)"
-    } > "$new"
-    cat "$new" "$old" > "$changelog"
-}
-
 refresh_shell() {
     cat 1>&2 <<EOF
 Dropping you into a shell. Either do
@@ -178,6 +125,7 @@ main() {
     local skip_branch_name_check="${SKIP_BRANCH_NAME_CHECK:-0}"
     local update_patches_only=false first_devel_upload=false first_sru=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
+    orig_hash=$(git describe --abbrev=8)
     local cur="" next="" 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
@@ -269,11 +217,10 @@ main() {
     fi
     is_devel=$(test "${ver_suff#*$devel_ver}" != "${ver_suff}" && echo "true" || echo "false")
 
-    local sru_bug_string="" skip_bugs=""
-    [ "${bug_refs_in_clog}" = "false" ] && skip_bugs="--skip-bugs"
+    local sru_bug_string=""
     if [ "${is_devel}" = "false" ] && [ "${first_devel_upload}" = "false" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
-        skip_bugs="--skip-bugs"
+        skip_bugs="true"
     fi
 
     # turn 0.7.7-10-gbc2c326-0ubuntu1 into 'bc2c326'
@@ -355,11 +302,11 @@ main() {
             done
             git commit -m "$msg" "$dpseries" $drops
 
-            msg="  * drop the following cherry-picks now included:"
+            msg="drop the following cherry-picks now included:"
             for file in $drops; do
-                msg="${msg}$CR    + ${file##*/}"
+                msg="${msg}$CR+${file##*/}"
             done
-            add_changelog_entries "$msg" ||
+            python3 $(dirname $0)/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
                 fail "failed adding changelog entry cherry-pick drops."
             git commit -m "update changelog." debian/changelog ||
                 fail "failed to commit changelog changes for drops."
@@ -421,13 +368,13 @@ main() {
                 echo
                 echo "refresh patches against ${from_ref} commit" \
                      "${upstream_hash}:"
-                for i in ${refreshed}; do echo "  $i"; done)
+                for i in ${refreshed}; do echo "+$i"; done)
             git commit -m "$msg" $refreshed ||
                 fail "failed to commit refreshed patches: $refreshed"
             msg=$(
-                echo "  * refresh patches:"
-                for i in ${refreshed}; do echo "   + $i"; done)
-            add_changelog_entries "$msg" ||
+                echo "refresh patches:"
+                for i in ${refreshed}; do echo "+$i"; done)
+            python3 $(dirname $0)/add_changelog.py "${msg}" "${orig_hash}" "${bug_refs_in_clog}" ||
                 fail "failed adding changelog entry for refresh"
             git commit -m "update changelog." debian/changelog ||
                 fail "failed to commit changelog changes."
@@ -459,17 +406,8 @@ main() {
     fi
 
     local clog="${TEMP_D}/changelog" gitlog="${TEMP_D}/gitlog"
-    git log --first-parent --no-decorate --format=full \
-        "${prev_pkg_hash}..${from_ref}" >  "$gitlog" ||
-        fail "failed git log ${prev_pkg_hash}..${from_ref}"
-
-    local entries=""
-    header="  * $new_msg${sru_bug_string:+ ${sru_bug_string}}"
-    entries=`cat $gitlog | log2dch $skip_bugs`
-    add_changelog_entries "$header\n$entries" "${new_pkg_ver}" || fail
-
-    cat "$gitlog" | log2dch $skip_bugs > "new-upstream-changes.txt" ||
-        fail "failed log2dch"
+    header="$new_msg${sru_bug_string:+ ${sru_bug_string}}"
+    python3 $(dirname $0)/add_changelog.py "${header}" "${new_pkg_ver}" "${bug_refs_in_clog}" || fail
 
     dch -e || fail "dch -e exited $?"
 


### PR DESCRIPTION
# Commit message
```
git-buildpackage provides a utility `gbp dch` which can
git commit summaries directly into debian/changelogs.

This will allow for repo, branch or package specicialization of
changelog formatting override behavior.

By default  no changes are necessary for packaging repositories
which use new-upstream-snapshot.

To override package formatting or gbp-dch defaults in your project,
copy the gbp conf and formatter files into your debian/ directory
and modify as needed:

  cp uss-tableflip/scripts/gbp.conf debian/
  cp uss-tableflip/scripts/gbp_format_changelog debian/

gbp.* files located in a debian/ local directory will be used
instead of the defaults delivered by uss-tableflip repo.
```


# To test
## test clean new-upstream-snapshot from stable branch
```bash
git checkout upstream/ubuntu/impish -B ubuntu/impish
new-upstream-snapshot
git diff upstream/ubuntu/impish debian/changelog
```
## test append to UNRELEASED changelog from previous new-upstream-snapshot
```bash
git reset --hard upstream/ubuntu/impish
new-upstream-snapshot 53a995e2f852d043d51ad25c1b9afbbe1edafd57  # one commit less than tip of main
git diff upstream/ubuntu/impish debian/changelog 
# Pull in second round of upstream commits into UNRELEASED changelog entry
new-upstream-snapshot
git diff upstream/ubuntu/impish debian/changelog
```

## test commits containing LP: #BUG_ID aren't published on impish (stable release doesn't include bugs)
```bash
git reset --hard upstream/ubuntu/impish
# go back a number of commits to ensure we get commits which fixed bugs
git reset --hard 4aa83d4d9dcc44e9ff5f5e7df05757cd10862271 # release 22.1.-14 on impish branch
new-upstream-snapshot
# assert latest changelog only contains one (LP: #<BUG_ID>) because we are a stable release
dpkg-parsechangelog --count=1 | grep LP
```