### PR TITLE
Remove some quotes because bash is a horrible language

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -126,7 +126,7 @@ main() {
     local update_patches_only=false first_devel_upload=false first_sru=false bug_refs_in_clog=true skip_release=false sru_bug_fillstr="SRU_BUG_NUMBER_HERE"
 
     orig_hash=$(git describe --abbrev=8)
-    local cur="" next="" 
+    local cur="" next=""
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
         case "$cur" in
@@ -364,7 +364,10 @@ main() {
                 echo "refresh patches against ${from_ref} commit" \
                      "${upstream_hash}:"
                 for i in ${refreshed}; do echo "+$i"; done)
-            git commit -m "$msg" "$refreshed" ||
+            # Having quotes around $refreshed can cause failures.
+            # Please don't add them back unless you've tested on a branch with
+            # refreshed patches
+            git commit -m "$msg" $refreshed ||
                 fail "failed to commit refreshed patches: $refreshed"
             msg=$(
                 echo "refresh patches:"


### PR DESCRIPTION
```
Remove quotes from file list

git commit on a quoted file list was causing failures. Remove them. 
```

Example failure:
```
newt:cloud-init (ubuntu/bionic*) $ git reset --hard eed6d8958b5b0e61c4cf9e476119df20298b598e; new-upstream-snapshot --skip-release
HEAD is now at eed6d8958 update changelog
updating remote upstream for default commitish upstream/main.
Removing patch retain-apt-partner-pocket.patch
Restoring templates/sources.list.ubuntu.tmpl

Removing patch renderer-do-not-prefer-netplan.patch
Restoring tests/unittests/test_render_cloudcfg.py
Restoring config/cloud.cfg.tmpl

Removing patch ec2-dont-apply-full-imds-network-config.patch
Restoring tests/unittests/sources/test_ec2.py
Restoring cloudinit/sources/DataSourceEc2.py

Removing patch openstack-no-network-config.patch
Restoring tests/unittests/sources/test_openstack.py
Restoring cloudinit/sources/DataSourceOpenStack.py

No patches applied
error: pathspec 'debian/patches/ec2-dont-apply-full-imds-network-config.patch
debian/patches/openstack-no-network-config.patch
debian/patches/renderer-do-not-prefer-netplan.patch' did not match any file(s) known to git
failed to commit refreshed patches: debian/patches/ec2-dont-apply-full-imds-network-config.patch
debian/patches/openstack-no-network-config.patch
debian/patches/renderer-do-not-prefer-netplan.patch
reset to previous tip with: git reset --hard eed6d8958b5b0e61c4cf9e476119df20298b598e
```