### PR TITLE
tools/fix stable bug redact

### DIFF
--- a/scripts/gbp_format_changelog
+++ b/scripts/gbp_format_changelog
@@ -22,6 +22,7 @@ FILTER_UPSTREAM_COMMITERS = (  # cloud-init upstream author names
     "Chad Smith",
     "James Falcon",
     "Brett Holman",
+    "Alberto Contreras",
 )
 
 FILTER_NOISY_COMMIT_REGEX = (

--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -220,6 +220,7 @@ main() {
     local sru_bug_string=""
     if [ "${is_devel}" = "false" ] && [ "${first_devel_upload}" = "false" ]; then
         sru_bug_string="(LP: #$sru_bug_fillstr)"
+        bug_refs_in_clog=false
     fi
 
     new_pkg_debian="0ubuntu1"


### PR DESCRIPTION
    new-upstream-snapshot:fix table bug redact
    
    commit 9884f0f9 introduced a tooling regressing that no longer
    redacts LP bug numbers on non-devel series.
    
    Add back the bug_refs_in_clog=false on non-devel releases which
    will redact LP bug IDs during SRUs to stable Ubuntu releases