### PR TITLE
new-upstream-snapshot: support XX.X.X tag format

### DIFF
--- a/scripts/new-upstream-snapshot
+++ b/scripts/new-upstream-snapshot
@@ -230,7 +230,8 @@ main() {
 
     case "$new_upstream_ver" in
         *-[0-9]*-g[a-f0-9]*) new_msg="New upstream snapshot.";;
-        [0-9][0-9].[0-9]) new_msg="New upstream release.";;
+        [0-9][0-9].[0-9]|[0-9][0-9].[0-9].[0-9])
+            new_msg="New upstream release.";;
         [0-9].[0-9]|[0-9].[0-9][0-9])
             new_msg="New upstream release.";;
         *) fail "unrecognized upstream version '$new_upstream_ver'";;


### PR DESCRIPTION
currently a tag in the form XX.X.X is not matched in parsing code in `new-upstream-snapshot` 
```
arc~/cloud-init(ubuntu/devel|…) new-upstream-snapshot 22.3.1     
unrecognized upstream version '22.3.1'
```

this fixes the issue:
```
arc~/cloud-init(ubuntu/devel↓4|…) new-upstream-snapshot 22.3.1
  diff --git a/debian/changelog b/debian/changelog
```