### PR TITLE
Build package fixes

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -3,6 +3,7 @@
 
 VERBOSITY=0
 ASSUME_YES=false
+OFFLINE=false
 TEMP_D=""
 START_D="$PWD"
 FORMATS=".tar.gz .tar.xz .tar.bz2"
@@ -24,6 +25,7 @@ Usage: ${0##*/} [ options ] <<ARGUMENTS>>
 
    options:
       --ref R         what to build from [default to current branch].
+      --offline       perform no upstream orig.tar.gz downloads
     -o | --output D   put output in D. [default ../out]
 EOF
 }
@@ -31,14 +33,15 @@ EOF
 bad_Usage() { Usage 1>&2; [ $# -eq 0 ] || error "$@"; return 1; }
 
 prompt_yes_no() {
-    echo -n "$@" "? (y/n) "
-    if [ "${ASSUME_YES}" = "true" ]; then
-        echo "--yes"
+    [ "${ASSUME_YES}" = "true" ] && {
+        error "assuming yes to prompt:" "$@"
         return 0
-    fi
-    read RESP
-    if [ "${RESP}" = "y" ]; then
-        return 0
+    }
+    local resp
+    echo -n "$@" "? (y/n)  "
+    read resp || fail "failed to read user input"
+    if [ "$resp" = "y" ]; then
+       return 0
     fi
     return 1
 }
@@ -82,7 +85,7 @@ get_genchanges_version() {
     devel=$(distro-info --devel)
     [ "$suite" = "$devel" ] &&
         { debug 1 "-v not relevant for devel suite ($suite)"; return 0; }
-    [ "$(echo $suite | tr '[a-z]' '[A-Z]')" = "UNRELEASED" ] &&
+    [ "${suite^^}" = "UNRELEASED" ] &&
         { debug 1 "-v not relevant for unreleased"; return 0; }
     if ! command -v rmadison >/dev/null 2>&1; then
         debug 1 "rmadison not available."
@@ -118,6 +121,10 @@ get_genchanges_version() {
 get_orig_tarball() {
     local changelog_file="$1" dir="${2:-..}" offset="$3" verbose="$4"
     local tarball_fp
+    if [ "$OFFLINE" = "true" ]; then
+        error "Skipping download of orig.tar.gz due to --offline param"
+        return 0
+    fi
     if ! get-orig-tarball "${changelog_file}" "${dir}" ${offset:+--offset=${offset}} $verbose; then
         error "failed to get orig tarball for $pkg_name at $pkg_ver"
         return 1
@@ -133,13 +140,14 @@ get_orig_tarball() {
     error ${MSG_BORDER_LINE}
     error " Using orig tarball in $tarball_fp"
     sha256sum "${orig_tarball_fp}"
-    echo ${MSG_BORDER_LINE}
+    error ${MSG_BORDER_LINE}
     return 0
 }
 
+
 main() {
     local short_opts="ho:vy"
-    local long_opts="help,output:,offset:,ref:,yes,verbose"
+    local long_opts="help,offline,output:,offset:,ref:,yes,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -154,6 +162,7 @@ main() {
             -h|--help) Usage ; exit 0;;
                --offset) offset=$next; shift;;
             -o|--output) out_d=$next; shift;;
+            --offline) OFFLINE=true;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             -y|--yes) ASSUME_YES=true;;
                --ref) ref=$next; shift;;
@@ -185,6 +194,7 @@ main() {
         fail "failed to read Distribution from changelog"
 
     upstream_ver=${pkg_ver%-*}
+
     # turn 0.7.7-10-gbc2c326-0ubuntu1 into 'bc2c326'
     upstream_hash=${upstream_ver##*-g}
 
@@ -213,7 +223,7 @@ main() {
         mv "$wtd" "${TEMP_D}/$pkg_name-$pkg_ver"
         wtd="${TEMP_D}/$pkg_name-$pkg_ver"
     else
-        error "pkg_name=$pkg_name pkg_ver=$pkg_ver upstream_ver=$upstream_ver"
+        error "pkg_name=$pkg_name pkg_ver=$pkg_ver upstream_ver=$upstream_ver suite=$suite"
         local orig_tarball_fp="" orig_tarball_fp=""
         orig_tarball_fp=$(find_orig "${pkg_name}" "${upstream_ver}" .. ../dl)
         if [ -n "$orig_tarball_fp" ]; then
@@ -221,10 +231,10 @@ main() {
             if [ "${tarball_dir}" = "../dl" ]; then
                 # Download and compare this tarball with latest upstream
                 if ! get_orig_tarball debian/changelog ../dl "${offset}"; then
-                    if ! prompt_yes_no "No upstream tarball for ${upstream_ver}, should we" \
-                           "create a new orig.tar.gz from the local branch"; then
+                    prompt_yes_no "No upstream tarball for ${upstream_ver}, " \
+                        "should we create a new orig.tar.gz from the local " \
+                        "branch" ||
                         fail "No upstream tarball found for ${upstream_ver}"
-                    fi
                 fi
             fi
             if ! prompt_yes_no "Proceed with build-package"; then
@@ -254,9 +264,10 @@ main() {
                        fail "failed to make tarball"
                 fi
             else
-                error ${MSG_BORDER_LINE}
                 sleep 1
-                ./tools/make-tarball "--output=$orig_tarball_fp" "$upstream_hash" ||
+                error ${MSG_BORDER_LINE}
+                echo ./tools/make-tarball "--output=$orig_tarball_fp"
+                ./tools/make-tarball "--output=$orig_tarball_fp" ||
                     fail "failed to make tarball"
                 error ${MSG_BORDER_LINE}
             fi

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -2,9 +2,12 @@
 # https://gist.github.com/smoser/6391b854e6a80475aac473bba4ef0310
 
 VERBOSITY=0
+ASSUME_YES=false
 TEMP_D=""
 START_D="$PWD"
 FORMATS=".tar.gz .tar.xz .tar.bz2"
+
+MSG_BORDER_LINE="========================================"
 
 cleanup(){
     [ ! -d "$TEMP_D" ] || rm -Rf "$TEMP_D";
@@ -26,6 +29,19 @@ EOF
 }
 
 bad_Usage() { Usage 1>&2; [ $# -eq 0 ] || error "$@"; return 1; }
+
+prompt_yes_no() {
+    echo -n "$@" "? (y/n) "
+    if [ "${ASSUME_YES}" = "true" ]; then
+        echo "--yes"
+        return 0
+    fi
+    read RESP
+    if [ "${RESP}" = "y" ]; then
+        return 0
+    fi
+    return 1
+}
 
 debug() {
     local level=${1}; shift;
@@ -99,9 +115,31 @@ get_genchanges_version() {
     fi
 }
 
+get_orig_tarball() {
+    local changelog_file="$1" dir="${2:-..}" offset="$3" verbose="$4"
+    local tarball_fp
+    if ! get-orig-tarball "${changelog_file}" "${dir}" ${offset:+--offset=${offset}} $verbose; then
+        error "failed to get orig tarball for $pkg_name at $pkg_ver"
+        return 1
+    fi
+    tarball_fp=$(find_orig "${pkg_name}" "${upstream_ver}" "${dir}")
+    if [ -z "${tarball_fp}" ]; then
+        error "did not get a tarball at $upstream_ver with get-orig-tarball"
+        return 1
+    elif [ ! -f "$tarball_fp" ]; then
+        error "orig tarball not a file: $tarball_fp"
+        return 1
+    fi
+    error ${MSG_BORDER_LINE}
+    error " Using orig tarball in $tarball_fp"
+    sha256sum "${orig_tarball_fp}"
+    echo ${MSG_BORDER_LINE}
+    return 0
+}
+
 main() {
-    local short_opts="ho:v"
-    local long_opts="help,output:,offset:,ref:,verbose"
+    local short_opts="ho:vy"
+    local long_opts="help,output:,offset:,ref:,yes,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -117,6 +155,7 @@ main() {
                --offset) offset=$next; shift;;
             -o|--output) out_d=$next; shift;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
+            -y|--yes) ASSUME_YES=true;;
                --ref) ref=$next; shift;;
             --) shift; break;;
         esac
@@ -178,7 +217,23 @@ main() {
         local orig_tarball_fp="" orig_tarball_fp=""
         orig_tarball_fp=$(find_orig "${pkg_name}" "${upstream_ver}" .. ../dl)
         if [ -n "$orig_tarball_fp" ]; then
-            error "Using existing orig tarball in $orig_tarball_fp"
+            tarball_dir=$(dirname "$orig_tarball_fp")
+            if [ "${tarball_dir}" = "../dl" ]; then
+                # Download and compare this tarball with latest upstream
+                if ! get_orig_tarball debian/changelog ../dl "${offset}"; then
+                    if ! prompt_yes_no "No upstream tarball for ${upstream_ver}, should we" \
+                           "create a new orig.tar.gz from the local branch"; then
+                        fail "No upstream tarball found for ${upstream_ver}"
+                    fi
+                fi
+            fi
+            if ! prompt_yes_no "Proceed with build-package"; then
+                tar_dir=$(dirname "${orig_tarball_fp}")
+                error "Canceled build-package."
+                error "To replace orig.tar.gz with latest upstream:"
+                error "  get-orig-tarball debian/changelog ${tar_dir} -v"
+                exit 0
+            fi
         elif [ -x tools/make-tarball ]; then
             if [ ! -d "../dl" ]; then
                 mkdir ../dl ||
@@ -187,19 +242,28 @@ main() {
             fi
             orig_tarball="${pkg_name}_$(no_epoch "${upstream_ver}").orig.tar.gz"
             orig_tarball_fp="../dl/$orig_tarball"
-            error "creating $orig_tarball_fp using" \
-                "make-tarball --output=$orig_tarball_fp $upstream_hash"
-            ./tools/make-tarball "--output=$orig_tarball_fp" "$upstream_hash" ||
-                fail "failed to make tarball"
+            if prompt_yes_no "Check for an upstream cloud-init_${upstream_ver}.orig.tar.gz on which to base this debdiff"; then
+                if ! get_orig_tarball debian/changelog ../dl "${offset}"; then
+                   error ${MSG_BORDER_LINE}
+                   error " No cloud-init_${upstream_ver}.orig.tar.gz found"
+                   error "Creating $orig_tarball_fp using" \
+                   "make-tarball --output=$orig_tarball_fp $upstream_hash"
+                   error ${MSG_BORDER_LINE}
+                   sleep 1
+                   ./tools/make-tarball "--output=$orig_tarball_fp" "$upstream_hash" ||
+                       fail "failed to make tarball"
+                fi
+            else
+                error ${MSG_BORDER_LINE}
+                sleep 1
+                ./tools/make-tarball "--output=$orig_tarball_fp" "$upstream_hash" ||
+                    fail "failed to make tarball"
+                error ${MSG_BORDER_LINE}
+            fi
         else
-            get-orig-tarball -v ${offset:+--offset=${offset}} ||
-                fail "failed to get orig tarball for $pkg_name at $pkg_ver"
-            orig_tarball_fp=$(find_orig "${pkg_name}" "${upstream_ver}" ..)
-            [ -n "$orig_tarball_fp" ] ||
-                fail "did not get a tarball with get-orig-tarball"
-            [ -f "$orig_tarball_fp" ] ||
-                fail "orig tarball not a file: $orig_tarball_fp"
-            error "using orig tarball $orig_tarball_fp"
+            if ! get_orig_tarball "" "${offset}" -v; then
+                fail ""
+            fi
         fi
 
         local ofp_name

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -192,6 +192,11 @@ main() {
         fail "failed to read Source from changelog"
     suite=$(cd "$wtd" && dpkg-parsechangelog --show-field Distribution) ||
         fail "failed to read Distribution from changelog"
+    if [ "${suite^^}" = "UNRELEASED" ]; then
+        prompt_yes_no "Found ${suite} in debian/changelog." \
+            "Do you really want to build-package" ||
+                fail "Set debian/changelog '${suite}' to a public release name"
+    fi
 
     upstream_ver=${pkg_ver%-*}
 
@@ -239,9 +244,13 @@ main() {
             fi
             if ! prompt_yes_no "Proceed with build-package"; then
                 tar_dir=$(dirname "${orig_tarball_fp}")
-                error "Canceled build-package."
+                error "Cancelled build-package."
                 error "To replace orig.tar.gz with latest upstream:"
                 error "  get-orig-tarball debian/changelog ${tar_dir} -v"
+                if [ -x tools/make-tarball ]; then
+                    error "To create orig.tar.gz from local branch:"
+                    error "  ./tools/make-tarball ../dl/${pkg_name}_$upstream_ver.orig.tar.gz"
+                fi
                 exit 0
             fi
         elif [ -x tools/make-tarball ]; then

--- a/scripts/get-orig-tarball
+++ b/scripts/get-orig-tarball
@@ -5,6 +5,9 @@ TEMP_D=""
 FORMATS=".tar.gz .tar.xz .tar.bz2"
 DSC_UBUNTU_BASE_URL="http://launchpad.net/ubuntu/+archive/primary/+files"
 DSC_DEBIAN_BASE_URL="http://launchpad.net/debian/+archive/primary/+files"
+MSG_BORDER_LINE="========================================"
+
+
 
 error() { echo "$@" 1>&2; }
 fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
@@ -271,12 +274,6 @@ main() {
 dl_to_dir() {
     local src="$1" ver="$2" odir="$3" overwrite=${4:-false} orig=""
     local uver="${ver%-*}"
-    if orig=$(find_orig "$src" "$uver" "$odir"); then
-        if ! $overwrite; then
-            error "orig tarball existed at $orig. --overwrite to overwrite."
-            return 0;
-        fi
-    fi
 
     get_dsc_url "$src" "$ver" || return
     dsc_url=$_RET
@@ -298,13 +295,43 @@ dl_to_dir() {
         return 1
     }
 
-    orig=$(find_orig "$src" "$uver" "$TEMP_D") || {
+    upstream_orig=$(find_orig "$src" "$uver" "$TEMP_D") || {
         error "dget succeeded, but no orig tarball found."
         cat "$TEMP_D/${src}_${ver}.dsc" 1>&2
         ls $TEMP_D 1>&2;
         cd "$sdir"
         return 1
     }
+
+    if orig=$(find_orig "$src" "$uver" "$odir"); then
+        ORIG_SUM=$(sha256sum "${orig}" | awk '{print $1}' )
+        UPSTREAM_SUM=$(sha256sum "${upstream_orig}" | awk '{print $1}' )
+        if [ "${ORIG_SUM}" == "${UPSTREAM_SUM}" ]; then
+            error ${MSG_BORDER_LINE}
+            error "No difference between upstream orig.tar.gz and local."
+            error "No changes made to ${orig}"
+            error ${MSG_BORDER_LINE}
+            _RET="${odir}/${orig##*/}"
+            return 0
+        fi
+        error ${MSG_BORDER_LINE}
+        error " orig tarball existed at $orig and differs from upstream"
+        error " sha256sums of local and upstream:"
+        error "   (local) ${ORIG_SUM}"
+        error "   (upstream) ${UPSTREAM_SUM}"
+        error " Use --overwrite to use upstream automatically in the future"
+        error ${MSG_BORDER_LINE}
+        if [ "${overwrite}" = "false" ]; then
+            echo "Do you want to overwrite ${orig} with upstream? (y/n)"
+            read RESP
+            if [ "${RESP}" = "y" ]; then
+                orig=${upstream_orig}
+            fi
+        fi
+    else
+        # No preexisting orig.tar.gz, so copy it to output dir
+        orig=${upstream_orig}
+    fi
 
     cd "$sdir"
     mv "$orig" "$odir/"


### PR DESCRIPTION
## Commit messages (do not squash merge)
*  scripts: build-package try downloading upstream tarfile always
    
    Avoid inconsistencies invalid local orig.tar.gz created by
    tools/make-tarball by always attempting to download the latest
    match upstream orig.tar.gz file.
    
    If a local orig.tar.gz exists in ../dl, sha256sum it against
    upstream's matching version and prompt to use upstream orig.tar.gz
    to avoid invalid local orig.tar.gz being used as a debdiff basis.
    
    When no local orig.tar.gz exists, but an upstream orig.tar exists,
    use that upstream orig.tar.gz as basis for debdiff creation.
    
    When neither local orig.tar.gz nor upstream orig.tar.gz exists,
    allow ./tools/make-tarball to create that local tarfile from CWD.
    
    To accomplish this:
     - refactor get-orig-tarfile into a function which will raise
       conspicuous messages reporting when upstream tarfiles do not exist,
       were unable to be written locally, or when the local tarfile
       differs from upstream
     - add a prompt_yes_no function which will require user interactions
       when upstream releases differ from any locally found orig.tar.gz.
     - add a --yes or -y flag to build-package to avoid user interaction
       and automatically overwrite local orig.tar.gz when an upstream
       orig.tar.gz exists

* scripts: get-orig-tarball compare upstream orig.tar.gz to local
    
    Attempt to download and compare sha256sum of latest upstream
    orig.tar.gz against any local orig.tar.gz found and give a
    consipuous message and prompt option when replacing local
    orig.tar.gz with a preferred upstream if available.
    
    This avoids collisions where a project may have created a local
    orig.tar.gz which matches the name of an upstream released
    orig.tar.gz but contains invalid content.
    
    This is a common failure pattern when developers who are not
    primary uploaders of upstream releases attempt to use
    get-orig-tarball from developement downstream branches ubuntu/*
    and the project tooling happens to generate a local orig.tar.gz
    which doesn't match the checksums of official uploaded releases.
    
    The end result is any dputs of debdiffs based on invalid local
    orig.tar.gz result in emails from launchpad rejecting uploads
    because the uploaded debdiff is based on an invalid orig.tar.gz
