### PR TITLE
new_upstream_snapshot: get previous changelog distro when UNRELEASED

### DIFF
--- a/scripts/new_upstream_snapshot.py
+++ b/scripts/new_upstream_snapshot.py
@@ -385,7 +385,7 @@ def update_changelog(
 
     dch_command = "dch --no-multimaint "
     new_patch_version = ""
-    if patches_refreshed:
+    if patches_refreshed and not commitish_is_upstream_tag:
         m = re.match(
             r"^(?P<package_version>\d+\.\d+(\.\d+)?).*",
             changelog_details.version
@@ -463,6 +463,8 @@ def get_series_suffix(old_version):
 def show_release_steps(changelog_details, devel_distro, is_devel):
     """Because we all like automation telling us to do more things."""
     series = devel_distro if is_devel else changelog_details.distro
+    if series.upper() == "UNRELEASED":
+        series = get_changelog_distro()
     new_version = ChangelogDetails.get().version
     git_branch_name = capture(
         "git rev-parse --abbrev-ref HEAD"


### PR DESCRIPTION
This corrects the suggested dch -R -D UNRELEASED '' comment at end of snapshot.

Also, avoid preferring previous changelog version when quilt patches are updated AND we are snapshotting an annotated upstream tag.

The above avoids using invalid previous suffix .3 etc as we are on a brand new XX.YY SRU so suffix should be ~18.04.1.




# To test
```
git checkout upstream/ubuntu/bionic  -B ubuntu/bionic
new_upstream_snapshot.py -c 23.2 -b 2023110
```
### validate that the release steps documented as follows:
```
To release:
dch -r -D bionic ''
git commit -m 'releasing cloud-init version 23.2-0ubuntu0~18.04.1' debian/changelog
git tag ubuntu/23.2-0ubuntu0_18.04.1
```