### PR TITLE
build-package: handle upstream ver containing ~g<git-hash>

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -202,6 +202,8 @@ main() {
 
     # turn 0.7.7-10-gbc2c326-0ubuntu1 into 'bc2c326'
     upstream_hash=${upstream_ver##*-g}
+    # turn 23.3~3gbc2c326-0ubuntu1 into 'bc2c326'
+    upstream_hash=${upstream_ver##*~[0-9]g}
 
     local native=false
     local dsf="debian/source/format"


### PR DESCRIPTION
New upstream versioning in devel series for weekly releases will have the version format:
   <tag_major_minor>~<release_counter>g<git_hash>

For example, the 2nd weekly release to the ubuntu devel seres after the
upstream annotated tag 23.1 at git commit asdf123 will be:
   23.1~2gasdf123

Adapt build-package script to properly determine git hash by redacting the leading 
MM.NN~[0-9]g to determine the upstream hash from which this version was created.