### PR TITLE
upstream-release: replace full upstream-release patch version x.y.z

### DIFF
--- a/scripts/upstream-release
+++ b/scripts/upstream-release
@@ -62,7 +62,7 @@ if [ "$RESP" = "y" ]; then
   git pull
   git checkout -b upstream/$RELEASE_MAJOR_MINOR
   printf "%s\n%s\n\n%s\n" "$RELEASE_MAJOR_MINOR" "$CHANGELOG" "$(cat ChangeLog)" > ChangeLog
-  sed -i "s/$PREVIOUS_MAJOR_MINOR/$RELEASE_MAJOR_MINOR/" cloudinit/version.py
+  sed -i "s/${PREVIOUS_MAJOR_MINOR}[.0-9]*/$RELEASE_MAJOR_MINOR/" cloudinit/version.py
   git diff
   cat > commit.msg <<EOF
 Release $RELEASE_MAJOR_MINOR


### PR DESCRIPTION
When cloud-init sync's patch-level version into version.py, ensure the replaced version number replaces the previously released full major.minor.patch.

Formerly, upstream-release 23.3 23.2 would generate the diff:

-__VERSION__ = "23.2.2"
+__VERSION__ = "23.3.2"

Version diff is now corrected to represent: `__VERSION__ = "23.3"`