### PR TITLE
New VersionInfo class and ubuntu0->ubuntu1

### DIFF
--- a/scripts/new_upstream_snapshot.py
+++ b/scripts/new_upstream_snapshot.py
@@ -489,8 +489,12 @@ def get_new_version(
             # this is the first SRU to a series
             series_number = capture("distro-info --stable -r").stdout.strip()
             changelog_version = VersionInfo.from_string(
-                f"{commitish}-0ubuntu0~{series_number}.1"
+                f"{commitish}-0ubuntu1~{series_number}.1"
             )
+        if tag_info.hotfix:
+            # This is unfortunately only a heuristic. If devel is in
+            # feature freeze, this is likely to be wrong.
+            changelog_version = changelog_version.replace(ubuntu=0)
     elif is_devel:
         # If not an upstream tag, then bump current number. For devel this
         # looks something like:

--- a/tests/test_upstream_snapshot.py
+++ b/tests/test_upstream_snapshot.py
@@ -370,7 +370,7 @@ def test_first_sru_to_series(devel_setup, mock_new_sru, capsys):
         UPSTREAM_MAIN_VERSION, no_sru_bug=True, known_first_sru=True
     )
     details = ChangelogDetails.get()
-    assert str(details.version) == f"{UPSTREAM_MAIN_VERSION}-0ubuntu0~10.10.1"
+    assert str(details.version) == f"{UPSTREAM_MAIN_VERSION}-0ubuntu1~10.10.1"
     assert details.distro == "UNRELEASED"
     assert "Bugs fixed in this snapshot" not in details.changes
     assert "List of changes from upstream" in details.changes


### PR DESCRIPTION
See individual commits for their particular changes.

One thing to note that this won't change a current `0ubuntu0`. If our current version numbers have it, we'll need to manually update it once to be correct going forward.

Some of the devel options are now going unused, but that was technically true before. It's just more obvious now. I didn't remove those, as that could come in a separate PR...and we might want to bring them back if we're sure what's supposed to happen.