### PR TITLE
Fix/upstream local changes

### DIFF
--- a/scripts/build-package
+++ b/scripts/build-package
@@ -96,6 +96,11 @@ get_genchanges_version() {
         { debug 1 "-v not relevant for devel suite ($suite)"; return 0; }
     [ "${suite^^}" = "UNRELEASED" ] &&
         { debug 1 "-v not relevant for unreleased"; return 0; }
+    case "$suite" in
+        unstable|sid|testing)
+            debug 1 "no genchanges support for debian ($suite): skipping."
+            return 0;;
+    esac
     if ! command -v rmadison >/dev/null 2>&1; then
         debug 1 "rmadison not available."
         return 0

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -36,6 +36,10 @@ Usage: ${0##*/} [ options ] <<ARGUMENTS>>
       --ref R         what to build from [default to current branch].
       --offline       perform no upstream orig.tar.gz downloads
     -o | --output D   put output in D. [default ../out]
+
+         --skip-genchanges-version   do not attempt to find the
+                                     correct '-v<version>' flag.
+
 EOF
 }
 
@@ -161,7 +165,7 @@ get_orig_tarball() {
 
 main() {
     local short_opts="ho:vy"
-    local long_opts="help,offline,output:,offset:,ref:,yes,verbose"
+    local long_opts="help,offline,output:,offset:,ref:,skip-genchanges-version:,yes,verbose"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -169,6 +173,7 @@ main() {
         { bad_Usage; return; }
 
     local cur="" next="" out_d="../out" ref="" offset="0"
+    local do_genchanges_v=true
 
     while [ $# -ne 0 ]; do
         cur="$1"; next="$2";
@@ -176,7 +181,8 @@ main() {
             -h|--help) Usage ; exit 0;;
                --offset) offset=$next; shift;;
             -o|--output) out_d=$next; shift;;
-            --offline) OFFLINE=true;;
+               --offline) OFFLINE=true;;
+               --skip-genchanges-version) do_genchanges_v=false;;
             -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
             -y|--yes) ASSUME_YES=true;;
                --ref) ref=$next; shift;;
@@ -339,9 +345,12 @@ main() {
 
     # try to magically add '-v' if its not present.
     local genchanges_v=""
-    get_genchanges_version "$pkg_name" "$suite" " $* " ||
-        fail "Failed to get genchanges version for $pkg_name $suite ' $* '"
-    genchanges_v="$_RET"
+    if [ "${do_genchanges_v}" = "true" ]; then
+        get_genchanges_version "$pkg_name" "$suite" " $* " ||
+            fail "Failed to get genchanges version for $pkg_name $suite ' $* '" \
+            "try with --skip-genchanges-version"
+        genchanges_v="$_RET"
+    fi
 
     if [ $# -eq 0 ]; then
         set -- -d -S -nc ${genchanges_v}

--- a/scripts/build-package
+++ b/scripts/build-package
@@ -23,6 +23,15 @@ Usage: ${0##*/} [ options ] <<ARGUMENTS>>
 
    build a package, put output in ../out
 
+   By default debuild is invoked to build a source package with:
+       -d -S -nc -v<version>
+   -v<version> is deteremined heuristically for dpkg-genchanges(1).
+
+   If you want to build with other flags, add debuild flags on
+   the cmdline.  For example, to build with -sa:
+
+      ${0##*/} -- -d -S -sa -nc
+
    options:
       --ref R         what to build from [default to current branch].
       --offline       perform no upstream orig.tar.gz downloads

--- a/scripts/sbuild-it
+++ b/scripts/sbuild-it
@@ -12,9 +12,11 @@ Usage: ${0##*/} [ options ] dsc [arch [ release ] ]
    dsc and is required, arch and release are optional with defaults
 
    options:
-    -h | --help             display this message
-         --dry-run          only report what would be done
-         --no-arch-all      do not pass '--arch-all'
+    -h | --help               display this message
+         --dry-run            only report what would be done
+         --no-arch-all        do not pass '--arch-all'
+    -p | --pass-through OPT   pass OPT through to sbuild.
+                              this can be given multiple times
 EOF
 }
 
@@ -34,8 +36,8 @@ rel_from_changes() {
             _RET="${out%-proposed}" || return 1
 }
 
-short_opts="hv"
-long_opts="help,dry-run,chroot:,no-arch-all,verbose"
+short_opts="hvp:"
+long_opts="help,dry-run,chroot:,no-arch-all,verbose,pass-through:"
 getopt_out=$(getopt --name "${0##*/}" \
     --options "${short_opts}" --long "${long_opts}" -- "$@") &&
     eval set -- "${getopt_out}" ||
@@ -57,6 +59,7 @@ ifile=""
 schanges=""
 sbuild="sbuild"
 chroot=""
+pt=( )
 
 while [ $# -ne 0 ]; do
     cur=${1}; next=${2};
@@ -65,6 +68,7 @@ while [ $# -ne 0 ]; do
            --dry-run) dry_run=1;;
            --no-arch-all) arch_all="";;
            --chroot) chroot=$next; shift;;
+        -p|--pass-through) pt[${#pt[@]}]="$next"; shift;;
         -v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
         --) shift; break;;
     esac
@@ -153,9 +157,10 @@ case "$rel" in
         ;;
 esac
 
-debug 0 "$sbuild --dist=${rel} --arch=${arch}${chroot:+ --chroot=$chroot} ${arch_all:+ ${arch_all}} $dsc"
+set -- $sbuild "${pt[@]}" "--dist=${rel}" "--arch=${arch}" ${chroot:+"--chroot=$chroot"} ${arch_all:+"${arch_all}"} "$dsc"
+debug 0 "execute:" "$@"
 [ $dry_run -eq 0 ] || exit 0
 # --resolve-alternatives is used by the buildd systems
-exec $sbuild --resolve-alternatives ${chroot:+"--chroot=${chroot}"} "--dist=${rel}" "--arch=${arch}" ${arch_all} "$dsc"
+"$@"
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
This is a set of local changes that I had that I think are generally useful.


  * build-package: Add --skip-genchanges-version flag.
    
    If you dont want the genchanges heuristic to run, then
    you can pass this flag and it will not attempt.

  * Do not try to pick genchanges version for debian.
    
    The genchanges heuristic does not work on debian, so do not try.

  * build-package: Give better usage in --help.


  * Add --pt (passthrough) option to sbuild-it to pass args to sbuild.
    
    I needed this today when I wanted to add --purge-session=successful
    to the sbuild invocation.
    
    In the past, I had just used --dry-run and run the sbuild manually
    with the change, but this is somewhat nicer.
