### PR TITLE
bug: drop prev d/changelog hotfix when incrementing major/minor

### DIFF
--- a/scripts/new_upstream_snapshot.py
+++ b/scripts/new_upstream_snapshot.py
@@ -133,7 +133,7 @@ class VersionInfo:
         return VersionInfo(
             major=major or self.major,
             minor=minor or self.minor,
-            hotfix=hotfix if hotfix is not None else self.hotfix,
+            hotfix=hotfix if hotfix or any((major, minor)) else self.hotfix,
             debian=debian if debian is not None else self.debian,
             ubuntu=ubuntu if ubuntu is not None else self.ubuntu,
             series=series if series is not None else self.series,


### PR DESCRIPTION
When new_upstream_snapshot is performed from a commit 24.1 it applies the any new major.minor.patch values from the commit to the previous debian/changelog version. This is done to inherit any ather ubuntu or series-specific suffixes such as ~22.04.1.

This presents a problem when the new upstream tag is only a major.minor and the previos d/changelog version was major.minor.hotfix because the VersionInfo.replace method avoids setting hotfix version if it is None.

Update VersionInfo.replace to honor/set hotfix of None if either major or minor values have changed.