### PR TITLE
fix(log2dch): track Fixes: GH-<id>  for ChangeLog generation

### DIFF
--- a/scripts/log2dch
+++ b/scripts/log2dch
@@ -214,9 +214,9 @@ git_log_to_dch() {
                 ;;
             Author:*) author="${line#Author: }";;
             LP:*) bug_tracker="LP"; bugs="${bugs:+${bugs}, }${line#*: }";;
-            Fixes:*|Closes:*)
+            Fixes\ GH*|Closes\ GH*)
                 bug_tracker="GH";
-                bug="${line#*: }";
+                bug="${line#*\ GH-}";
                 [ ! -z "${bug##*[!0-9]*}" ] && bugs="${bugs:+${bugs}, }$bug";;
             "") [ -z "$subject" ] && read -r subject;;
         esac


### PR DESCRIPTION
    Upstream git commit messages carry the following footers to represent
    an issue is fixed or closed by a cmomit:
    
    Fixes GH-###
    Closes GH-###
    
    Allow log2dch to append (GH <id>)  to ChangeLog entry when encountering
    such a commit message footer.
