### PR TITLE
sort patches by default

### DIFF
--- a/scripts/new_upstream_snapshot.py
+++ b/scripts/new_upstream_snapshot.py
@@ -26,7 +26,7 @@ sh = partial(subprocess.run, check=True, shell=True)
 capture = partial(sh, capture_output=True, universal_newlines=True)
 
 QUILT_COMMAND = "quilt --quiltrc -"
-QUILT_DIFF_ARGS = "-p ab --no-timestamps --no-index"
+QUILT_DIFF_ARGS = "-p ab --no-timestamps --no-index --sort"
 QUILT_ENV = {
     "QUILT_PATCHES": "debian/patches",
     "QUILT_DIFF_OPTS": "-p",

--- a/scripts/new_upstream_snapshot.py
+++ b/scripts/new_upstream_snapshot.py
@@ -662,7 +662,10 @@ def get_possible_devel_options(
     """
     is_devel = is_first_devel_upload = known_first_devel_upload
     is_first_sru = known_first_sru
-    devel_distro = capture("distro-info --devel").stdout.strip()
+    try:
+        devel_distro = capture("distro-info --devel").stdout.strip()
+    except Exception:
+        devel_distro = "UNKNOWN"
     if is_first_devel_upload and is_first_sru:
         raise CliError(
             "Can't simultaneously be first SRU and first devel upload"


### PR DESCRIPTION
This will produce smaller diffs by default (after the initial sort).

Also, use a more useful default when no distro-info is available